### PR TITLE
change default cutoff max to that used in 2FGL

### DIFF
--- a/enrico/xml_model.py
+++ b/enrico/xml_model.py
@@ -218,7 +218,7 @@ def addPSPLSuperExpCutoff(lib, name, ra, dec, eflux=0,
                    index1_free=1, index1_value=-2.0,
                    index1_min=-5.0, index1_max=-0.,
                    cutoff_free=1, cutoff_value=1e4,
-                   cutoff_min=200, cutoff_max=3e5,
+                   cutoff_min=200, cutoff_max=1e8,
                    index2_free=0, index2_value=1.0,
                    index2_min=0.0, index2_max=5.0,extendedName=""):
     """Add a source with a SUPEREXPCUTOFF model"""


### PR DESCRIPTION
The default upper bound for exponential cutoffs in 2FGL is 100 TeV, this changes it in enrico to reflect that. It is unusual for sources in 2FGL to go above the previous upper bound of 3e5, but I found one (2FGL J1823.4-3014) and gtsrcmaps failed as a result.
