### PR TITLE
add analysis tags to new directories

### DIFF
--- a/enrico/RunGTlike.py
+++ b/enrico/RunGTlike.py
@@ -65,7 +65,7 @@ def run(infile):
     #plot the SED and model map if possible and asked
     if config['Spectrum']['ResultPlots'] == 'yes' :
         from enrico.constants import SpectrumPath
-    	os.system("mkdir -p "+config['out'] + '/'+SpectrumPath+'/')
+        os.system("mkdir -p "+config['out'] + '/'+SpectrumPath+"_"+config['file']['tag']+'/')
         if float(config['UpperLimit']['TSlimit']) < Fit.Ts(config['target']['name']):
             FitRunner.ComputeSED(Fit)
         outXml = utils._dump_xml(config)

--- a/enrico/fitmaker.py
+++ b/enrico/fitmaker.py
@@ -320,8 +320,9 @@ class FitMaker(Loggin.Message):
         self._log('PlotSED', 'Generate SED plot')
         import plotting#plotting is the dedicated library
         from enrico.constants import SpectrumPath
-        filename = self.config['out'] + '/'+SpectrumPath+'/SED_' + self.obs.srcname +'_'+ self.config['target']['spectrum']
-        Param = plotting.Params(self.obs.srcname, Emin=self.obs.Emin, 
+        filename = (self.config['out'] + '/'+SpectrumPath+'_'+self.config['file']['tag']+
+                '/SED_' + self.obs.srcname +'_'+ self.config['target']['spectrum'])
+        Param = plotting.Params(self.obs.srcname, Emin=self.obs.Emin,
                               Emax=self.obs.Emax, PlotName=filename)
         result = plotting.Result(Fit, Param)
         result._DumpSED(Param)

--- a/enrico/lightcurve.py
+++ b/enrico/lightcurve.py
@@ -83,9 +83,9 @@ class LightCurve(Loggin.Message):
 
 
     def _ManageFolder(self,path):
-        """   All files will be stored in a subfolder name path + NLCbin
+        """   All files will be stored in a subfolder name path + tag + NLCbin
         Create a subfolder"""
-        self.LCfolder =  self.folder+"/LightCurve_"+str(self.Nbin)+"bins/"
+        self.LCfolder =  self.folder+"/"+path+"_"+self.config['file']['tag']+"_"+str(self.Nbin)+"bins/"
         os.system("mkdir -p "+self.LCfolder)
         self.config['out'] = self.LCfolder
 
@@ -113,7 +113,7 @@ class LightCurve(Loggin.Message):
             self.configfile.append(filename)
 
 
-    def _MakeLC(self,Path=LightcurvePath) :
+    def _MakeLC(self) :
         '''Main function of the Lightcurve script. Read the config file and run the gtlike analysis'''
         enricodir = environ.DIRS.get('ENRICO_DIR')
         fermidir = environ.DIRS.get('FERMI_DIR')

--- a/enrico/scan.py
+++ b/enrico/scan.py
@@ -51,12 +51,13 @@ def Scan(config):
           tgr.SetLineColor(2)
           tgr.Draw('AL')
 
-          os.system("mkdir -p "+config["out"]+"/"+cst.ScanPath)
-          savefile = open(config["out"]+"/"+cst.ScanPath+ "/Scan_"+par+".txt","w")
+          Path = config["out"]+"/"+cst.ScanPath+"_"+config['file']['tag']
+          os.system("mkdir -p "+Path)
+          savefile = open(Path+ "/Scan_"+par+".txt","w")
           for i in xrange(param.size):
              savefile.write(str(param[i])+" "+str(loglike[i])+"\n")
           savefile.close()
-          cres.Print(config["out"]+"/"+cst.ScanPath+ "/Scan_"+par+".eps")
-          cres.Print(config["out"]+"/"+cst.ScanPath+ "/Scan_"+par+".C")
-          cres.Print(config["out"]+"/"+cst.ScanPath+ "/Scan_"+par+".png")
+          cres.Print(Path+ "/Scan_"+par+".eps")
+          cres.Print(Path+ "/Scan_"+par+".C")
+          cres.Print(Path+ "/Scan_"+par+".png")
 

--- a/enrico/tsmap.py
+++ b/enrico/tsmap.py
@@ -28,7 +28,7 @@ class TSMap(Loggin.Message):
         Loggin.Message.__init__(self)
         self.config = config
         self.config['Spectrum']['FitsGeneration'] = 'no'
-        self.tsfolder = self.config['out']+"/"+TSMapPath
+        self.tsfolder = self.config['out']+"/"+TSMapPath+"_"+self.config['file']['tag']
         self.TSfits = self.config['target']['name']+'_'+self.config['file']['tag']+"_TSMap.fits"
         self.infile = infile
         self.npix = self.config['TSMap']['npix']


### PR DESCRIPTION
I have added the config['file']['tag'] to the newly generated paths (TSMap, Lightcurve, Spectrum) so that analysis with two different tags (but possibly sharing other files, such as the model) can be run in the same directory.