### PR TITLE
fix undeclared extendedsrcname

### DIFF
--- a/enrico/xml_model.py
+++ b/enrico/xml_model.py
@@ -308,10 +308,10 @@ def GetlistFromFits(config, catalog):
       extendedfits    = cfile[5].data.field('Spatial_Filename')
       extendedsrcname = cfile[5].data.field('Source_Name')
     except:
-      mes.warning("Cannot find th extended source list: please check the xml")
+      mes.warning("Cannot find the extended source list: please check the xml")
       extendedName = np.array(names.size*[""])
+      extendedsrcname = []
 
-    
 
     sigma = data.field('Signif_Avg')
 


### PR DESCRIPTION
When using a 2FGL catalog as source for enrico_xml, the variable extendedsrcname is not declared when the field ``Extended_Source_Name``, or the extended FITS extension are not found. This PR declares extendedsrcname to an empty list so the comparison in line 330 doesn't fail.