### PR TITLE
Several changes (new LRT macro + small changes on AppLC)

### DIFF
--- a/bin/enrico_lrt
+++ b/bin/enrico_lrt
@@ -19,18 +19,15 @@ except:
     print('Usage: '+sys.argv[0]+' <config file name> <modelfile>')
     mes.error('Config file or modelfile not found.')
 
-
 if len(sys.argv)==3:
     # Read a file containing a list of config files.
     config = get_config(infile)
     ModelTest = ModelTester(config)
     ModelTest.TestModelFromFile(sys.argv[2])
-else:
-    # Back to enrico_likelihood case
-    cfgfile = sys.argv[1]
-    mes.info("work on the config file "+cfgfile)
-    config = get_config(cfgfile)
+elif:
+    # Back to enrico_likelihood cae
+    config = get_config(infile)
     ModelTest = ModelTester(config)
-    ModelTest.TestModelFromFile(sys.argv[2])
+    ModelTest.TestModel()
 
 

--- a/bin/enrico_lrt
+++ b/bin/enrico_lrt
@@ -7,6 +7,12 @@ from enrico.config import get_config
 from enrico.testModel import ModelTester
 from enrico import Loggin
 mes = Loggin.Message()
+
+# Usage example: enrico_lrt PG1553.conf lrt.test
+# Where PG1553.conf is a standard enrico config file
+# and lrt.test contain the model parameters:
+# e.g. LogParabola, None, 1.571613825, 0.06406550853
+
 try:
     infile = sys.argv[1]
 except:
@@ -14,23 +20,16 @@ except:
     mes.error('Config file or modelfile not found.')
 
 
-if len(sys.argv)==3 :
-#read an config file alone. If not working, try to read an ascii file with different conf file
-  try : 
-    liste = np.genfromtxt(sys.argv[1],dtype="str",unpack=True)
-    for inf in liste:
-      mes.info("work on the config file "+inf)
-      config = get_config(inf)
-      ModelTest = ModelTester(config)
-      ModelTest.TestModelFromFile(sys.argv[2])
-  except :
+if len(sys.argv)==3:
+    # Read a file containing a list of config files.
     config = get_config(infile)
     ModelTest = ModelTester(config)
     ModelTest.TestModelFromFile(sys.argv[2])
 else:
-    inf = sys.argv[1]
-    mes.info("work on the config file "+inf)
-    config = get_config(inf)
+    # Back to enrico_likelihood case
+    cfgfile = sys.argv[1]
+    mes.info("work on the config file "+cfgfile)
+    config = get_config(cfgfile)
     ModelTest = ModelTester(config)
     ModelTest.TestModelFromFile(sys.argv[2])
 

--- a/bin/enrico_lrt
+++ b/bin/enrico_lrt
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Run fit with gtlike and a custom model to compute the log like"""
+import sys
+import logging
+import numpy as np
+from enrico.config import get_config
+from enrico.testModel import ModelTester
+from enrico import Loggin
+mes = Loggin.Message()
+try:
+    infile = sys.argv[1]
+except:
+    print('Usage: '+sys.argv[0]+' <config file name> <modelfile>')
+    mes.error('Config file or modelfile not found.')
+
+
+if len(sys.argv)==3 :
+#read an config file alone. If not working, try to read an ascii file with different conf file
+  try : 
+    liste = np.genfromtxt(sys.argv[1],dtype="str",unpack=True)
+    for inf in liste:
+      mes.info("work on the config file "+inf)
+      config = get_config(inf)
+      ModelTest = ModelTester(config)
+      ModelTest.TestModelFromFile(sys.argv[2])
+  except :
+    config = get_config(infile)
+    ModelTest = ModelTester(config)
+    ModelTest.TestModelFromFile(sys.argv[2])
+else:
+    inf = sys.argv[1]
+    mes.info("work on the config file "+inf)
+    config = get_config(inf)
+    ModelTest = ModelTester(config)
+    ModelTest.TestModelFromFile(sys.argv[2])
+
+

--- a/bin/enrico_lrt
+++ b/bin/enrico_lrt
@@ -24,7 +24,7 @@ if len(sys.argv)==3:
     config = get_config(infile)
     ModelTest = ModelTester(config)
     ModelTest.TestModelFromFile(sys.argv[2])
-elif:
+else:
     # Back to enrico_likelihood cae
     config = get_config(infile)
     ModelTest = ModelTester(config)

--- a/bin/enrico_lrt
+++ b/bin/enrico_lrt
@@ -21,11 +21,13 @@ except:
 
 if len(sys.argv)==3:
     # Read a file containing a list of config files.
+    mes.info("work on the config file "+infile)
     config = get_config(infile)
     ModelTest = ModelTester(config)
     ModelTest.TestModelFromFile(sys.argv[2])
 else:
-    # Back to enrico_likelihood cae
+    # Back to enrico_likelihood case
+    mes.info("work on the config file "+infile)
     config = get_config(infile)
     ModelTest = ModelTester(config)
     ModelTest.TestModel()

--- a/doc/source/tools.rst
+++ b/doc/source/tools.rst
@@ -26,3 +26,4 @@ ScienceTools are described `here <http://fermi.gsfc.nasa.gov/ssc/data/analysis/s
 * ``enrico_scan`` : make a profile likelihood for each free parameter of the target
 * ``enrico_findsrc`` : run gtfindsource
 * ``enrico_contour`` : make a confidence contour of 2 parameters
+* ``enrico_lrt`` : test custom spectral shapes by calculating their likelihoods

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -74,6 +74,9 @@ Statement enclosed in [] are default, being there to help you.
    Target Name : PG155+113
    Right Ascension: 238.92935
    Declination: 11.190102
+   redshift, no effect if null [0] : 0.49
+   ebl model to used
+   0=Kneiske, 1=Primack05, 2=Kneiske_HighUV, 3=Stecker05, 4=Franceschini, 5=Finke, 6=Gilmore : 4
    Options are : PowerLaw, PowerLaw2, LogParabola, PLExpCutoff
    Spectral Model [PowerLaw] : PowerLaw2
    ROI Size [15] : 10
@@ -84,7 +87,13 @@ Statement enclosed in [] are default, being there to help you.
    End time [334165418] : 256970880
    Emin [100] : 200
    Emax [300000] : 
-
+   IRFs [CALDB] : 
+   evclass [128] : 
+   evtype [3] : 
+   Corresponding IRFs	=	('P8R2_SOURCE_V6', ['BACK', 'FRONT'])
+   Is this ok? [y] : y
+   Corresponding zmax =  95
+   
 Note :
 
 * Always give the full path for the files

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -401,14 +401,30 @@ The tool `enrico_contour` allows to make a contour of 2  free parameters of the 
 Get the highest energy events
 -----------------------
 
-The tool `enrico_srcprob' compute the highest energy photons that can be associated to a list of sources (provided in an ascii file). The probability of the photons to be associated to the sources is also computed
+The tool `enrico_srcprob` compute the highest energy photons that can be associated to a list of sources (provided in an ascii file). The probability of the photons to be associated to the sources is also computed
 
 Refine source position
 -----------------------
 
-The tool `enrico_findsrc' is based on gtfindsource and find the best position of a source
+The tool `enrico_findsrc` is based on gtfindsource and find the best position of a source
 
 Check different models
 ----------------------
 
 `enrico_testmodel` will run the gtlike analysis with different model and compute the loglikehihood value for each model. The user can then decide, base on a LRT which model best describe the data. Fits files must have been generated before.
+
+Test a particular model list
+----------------------------
+
+`enrico_lrt` will run the gtlike analysis with a (list of) model(s) given as lines in a models file. The user can decide which parameters are to be fixed (by specifying a value) and which ones are going to be free (None value). 
+
+Lines should contain something like: LogParabola, None, 1.571613825, 0.06406550853 
+
+Then we call the lrt macro by running:
+
+`enrico_lrt mysourceconfig.conf mylistofmodels.txt`
+
+The macro uses Pickle to save Fit results (in order to accelerate future queries).
+Results and files will be saved to the /TestModel/ subdirectory. The .results file
+contains the likelihood value appended to the end of the model 
+

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -424,7 +424,12 @@ Then we call the lrt macro by running:
 
 `enrico_lrt mysourceconfig.conf mylistofmodels.txt`
 
-The macro uses Pickle to save Fit results (in order to accelerate future queries).
+If no list of models is specified, enrico_lrt will execute the routines in 
+enrico_testmodel.
+
 Results and files will be saved to the /TestModel/ subdirectory. The .results file
-contains the likelihood value appended to the end of the model 
+contains the likelihood value appended to the end of the model. Please note that
+the formatting is slightly different than in `enrico_testmodel` (comma separated
+instead of tab separated values)
+
 

--- a/enrico/appertureLC.py
+++ b/enrico/appertureLC.py
@@ -22,8 +22,9 @@ def AppLC(infile):
     LCoutfolder = folder+"/"+AppLCPath
     os.system("mkdir -p "+LCoutfolder)
 
-    #Change the ROI to 1 degree
-    config['space']['rad'] = 1
+    #Change the ROI to the desired radius in degree, legacy 1 deg.
+    try: config['space']['rad'] = config['AppLC']['rad']
+    except NameError: config['space']['rad'] = 1
 
     Nbins = config['AppLC']['NLCbin']#Number of bins
     #Get The time bin

--- a/enrico/config/default.conf
+++ b/enrico/config/default.conf
@@ -148,6 +148,8 @@ Submit = option('yes', 'no', default='no')
 	FitsGeneration = option('yes', 'no', default='yes')
 	#Spectral index for the exposure calculation
 	index = float(default=1.5)
+  #Apperture radius 
+	rad = float(default=1)
 	#Number of bins
 	NLCbin = integer(default=10)
 	#bin form data or frozen bin size

--- a/enrico/lightcurve.py
+++ b/enrico/lightcurve.py
@@ -235,6 +235,9 @@ class LightCurve(Loggin.Message):
             IndexName = 'Index1'
             CutoffName = 'Cutoff'
             CutoffErrName = 'dCutoff'
+        else:
+            IndexName = 'alpha'
+            CutoffName = None
         IndexErrName = 'd' + IndexName
 
         Nfail = 0
@@ -476,7 +479,20 @@ class LightCurve(Loggin.Message):
 
             #Spectral index management!
             self.info("Spectral index frozen to a value of 2")
-            utils.FreezeParams(Fit, self.srcname, 'Index', -2)
+            if (self.config['target']['spectrum'] == 'PowerLaw' or
+                self.config['target']['spectrum'] == 'PowerLaw2'):
+                IndexName = 'Index'
+                IndexValue = -2
+            elif (self.config['target']['spectrum'] == 'PLExpCutoff' or
+                self.config['target']['spectrum'] == 'PLSuperExpCutoff'):
+                IndexName = 'Index1'
+                IndexValue = -2
+            else:
+                IndexName = 'alpha'
+                IndexValue = 0.5
+
+            utils.FreezeParams(Fit, self.srcname, IndexName, IndexValue)
+
             LogL1.append(-Fit.fit(0,optimizer=CurConfig['fitting']['optimizer']))
 
             Model_type = Fit.model.srcs[self.srcname].spectrum().genericName()

--- a/enrico/testModel.py
+++ b/enrico/testModel.py
@@ -19,6 +19,8 @@ class ModelTester(Loggin.Message):
         self.folder = self.config['out']
         os.system("mkdir -p "+self.folder+"/TestModel")
         self.modellist = ["PowerLaw","LogParabola","PLSuperExpCutoff"]
+        
+        '''
         try:
             with open(self.folder+"/TestModel/Fit.pickle","r") as pfile:
                 print("Retrieving previous Fit from %s" \
@@ -33,6 +35,9 @@ class ModelTester(Loggin.Message):
                 print("Saving current Fit to %s" \
                     %(self.folder+"/TestModel/Fit.pickle"))
                 pickle.dump(self.FitRunner,pfile)
+        '''
+        self._GenFit()
+        self.FitRunner.PerformFit(self.Fit, False)
 
         # Store the results in a dictionnary
         self.Results = {}

--- a/enrico/testModel.py
+++ b/enrico/testModel.py
@@ -121,14 +121,17 @@ class ModelTester(Loggin.Message):
             if self.Fit.model[i].isFree():
                 self.Fit.freeze(i)
         
-        # Release diffuse models (background)
-        self.Fit.thaw(self.Fit.par_index("IsoDiffModel", 'Normalization'))
-        self.Fit.thaw(self.Fit.par_index("GalDiffModel", 'Value'))
-
         self.info("Computing loglike value for "+model)
         #self._GenFit()
         self.Fit.logLike.getSource(srcname).setSpectrum(model)
         
+        if (pars==None):
+            pars=[None,None,None,None]
+        else:
+            # Release diffuse models (background)
+            self.Fit.thaw(self.Fit.par_index("IsoDiffModel", 'Normalization'))
+            self.Fit.thaw(self.Fit.par_index("GalDiffModel", 'Value'))
+
         if model=="PowerLaw":
             self._setPowerLaw(srcname,pars)
         if model=="LogParabola":
@@ -146,7 +149,6 @@ class ModelTester(Loggin.Message):
           self.Fit.writeXml(self.folder+"/TestModel/TestModel"+model+".xml")
           return self.Fit.logLike.value()
         except :
-          raise
           self.warning("No convergence for model : "+model+" ??")
           return 0
 
@@ -165,19 +167,18 @@ class ModelTester(Loggin.Message):
         SrcSpectrum.getParam('Scale').setBounds(20,3e6)
         
         # Set each non-None parameter to the wanted value and fix it.
-        if pars!=None:
-            if pars[0]!=None:
-                print("Fixing Prefactor")
-                SrcSpectrum.getParam('Prefactor').setFree(0)
-                SrcSpectrum.getParam('Prefactor').setValue(pars[0]/1e-11)
-                par = self.Fit.par_index(name, 'Prefactor')
-                self.Fit.freeze(par)
-            if pars[1]!=None:
-                print("Fixing Index")
-                SrcSpectrum.getParam('Index').setScale(pars[1])
-                SrcSpectrum.getParam('Index').setFree(0)
-                par = self.Fit.par_index(name, 'Prefactor')
-                self.Fit-freeze(par)
+        if pars[0]!=None:
+            print("Fixing Prefactor")
+            SrcSpectrum.getParam('Prefactor').setFree(0)
+            SrcSpectrum.getParam('Prefactor').setValue(pars[0]/1e-11)
+            par = self.Fit.par_index(name, 'Prefactor')
+            self.Fit.freeze(par)
+        if pars[1]!=None:
+            print("Fixing Index")
+            SrcSpectrum.getParam('Index').setScale(pars[1])
+            SrcSpectrum.getParam('Index').setFree(0)
+            par = self.Fit.par_index(name, 'Prefactor')
+            self.Fit-freeze(par)
 
 
     def _setLogParabola(self,name,pars=None):
@@ -200,25 +201,24 @@ class ModelTester(Loggin.Message):
         SrcSpectrum.getParam('Eb').setBounds(20,3e6) 
         
         # Set each non-None parameter to the wanted value and fix it.
-        if pars!=None:
-            if pars[0]!=None:
-                print("Fixing norm")
-                SrcSpectrum.getParam('norm').setFree(0)
-                SrcSpectrum.getParam('norm').setValue(pars[0]/1e-11)
-                par = self.Fit.par_index(name, 'norm')
-                self.Fit.freeze(par)
-            if pars[1]!=None:
-                print("Fixing alpha")
-                SrcSpectrum.getParam('alpha').setFree(0)
-                SrcSpectrum.getParam('alpha').setScale(pars[1])
-                par = self.Fit.par_index(name, 'alpha')
-                self.Fit.freeze(par)
-            if pars[2]!=None:
-                print("Fixing beta")
-                SrcSpectrum.getParam('beta').setFree(0)
-                SrcSpectrum.getParam('beta').setScale(pars[2])
-                par = self.Fit.par_index(name, 'beta')
-                self.Fit.freeze(par)
+        if pars[0]!=None:
+            print("Fixing norm")
+            SrcSpectrum.getParam('norm').setFree(0)
+            SrcSpectrum.getParam('norm').setValue(pars[0]/1e-11)
+            par = self.Fit.par_index(name, 'norm')
+            self.Fit.freeze(par)
+        if pars[1]!=None:
+            print("Fixing alpha")
+            SrcSpectrum.getParam('alpha').setFree(0)
+            SrcSpectrum.getParam('alpha').setScale(pars[1])
+            par = self.Fit.par_index(name, 'alpha')
+            self.Fit.freeze(par)
+        if pars[2]!=None:
+            print("Fixing beta")
+            SrcSpectrum.getParam('beta').setFree(0)
+            SrcSpectrum.getParam('beta').setScale(pars[2])
+            par = self.Fit.par_index(name, 'beta')
+            self.Fit.freeze(par)
 
 
 
@@ -245,29 +245,28 @@ class ModelTester(Loggin.Message):
         SrcSpectrum.getParam('Scale').setBounds(20,3e6)
         
         # Set each non-None parameter to the wanted value and fix it.
-        if pars!=None:
-            if pars[0]!=None:
-                print("Fixing Prefactor")
-                SrcSpectrum.getParam('Prefactor').setFree(0)
-                SrcSpectrum.getParam('Prefactor').setValue(pars[0]/1e-11)
-                par = self.Fit.par_index(name, 'Prefactor')
-                self.Fit.freeze(par)
-            if pars[1]!=None:
-                print("Fixing Index1")
-                SrcSpectrum.getParam('Index1').setScale(pars[1])
-                SrcSpectrum.getParam('Index1').setFree(0)
-                par = self.Fit.par_index(name, 'Index1')
-                self.Fit.freeze(par)
-            if pars[2]!=None:
-                print("Fixing Index2")
-                SrcSpectrum.getParam('Index2').setScale(pars[2])
-                SrcSpectrum.getParam('Index2').setFree(0)
-                par = self.Fit.par_index(name, 'Index2')
-                self.Fit.freeze(par)
-            if pars[3]!=None:
-                print("Fixing Cutoff")
-                SrcSpectrum.getParam('Cutoff').setScale(pars[3])
-                SrcSpectrum.getParam('Cutoff').setFree(0)
-                par = self.Fit.par_index(name, 'Cutoff')
-                self.Fit.freeze(par)
+        if pars[0]!=None:
+            print("Fixing Prefactor")
+            SrcSpectrum.getParam('Prefactor').setFree(0)
+            SrcSpectrum.getParam('Prefactor').setValue(pars[0]/1e-11)
+            par = self.Fit.par_index(name, 'Prefactor')
+            self.Fit.freeze(par)
+        if pars[1]!=None:
+            print("Fixing Index1")
+            SrcSpectrum.getParam('Index1').setScale(pars[1])
+            SrcSpectrum.getParam('Index1').setFree(0)
+            par = self.Fit.par_index(name, 'Index1')
+            self.Fit.freeze(par)
+        if pars[2]!=None:
+            print("Fixing Index2")
+            SrcSpectrum.getParam('Index2').setScale(pars[2])
+            SrcSpectrum.getParam('Index2').setFree(0)
+            par = self.Fit.par_index(name, 'Index2')
+            self.Fit.freeze(par)
+        if pars[3]!=None:
+            print("Fixing Cutoff")
+            SrcSpectrum.getParam('Cutoff').setScale(pars[3])
+            SrcSpectrum.getParam('Cutoff').setFree(0)
+            par = self.Fit.par_index(name, 'Cutoff')
+            self.Fit.freeze(par)
 

--- a/enrico/testModel.py
+++ b/enrico/testModel.py
@@ -128,11 +128,15 @@ class ModelTester(Loggin.Message):
         
         if pars!=None:
             if pars[0]!=None:
+                print("Fixing Prefactor")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Prefactor').setScale(1e-11)
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Prefactor').setValue(pars[0]/1e-11)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Prefactor').setBounds(pars[0],pars[0])
             if pars[1]!=None:
+                print("Fixing Index")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index').setScale(pars[1])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index').setFree(0)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index').setBounds(pars[1],pars[1])
 
 
     def _setLogParabola(self,name,pars=None):
@@ -154,14 +158,20 @@ class ModelTester(Loggin.Message):
         
         if pars!=None:
             if pars[0]!=None:
+                print("Fixing norm")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('norm').setScale(1e-11)
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('norm').setValue(pars[0]/1e-11)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('norm').setBounds(pars[0]/1e-11,pars[0]/1e-11)
             if pars[1]!=None:
+                print("Fixing alpha")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('alpha').setScale(pars[1])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('alpha').setFree(0)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('alpha').setBounds(pars[1],pars[1])
             if pars[2]!=None:
+                print("Fixing beta")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('beta').setScale(pars[2])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('beta').setFree(0)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('beta').setBounds(pars[2],pars[2])
 
 
 
@@ -187,15 +197,23 @@ class ModelTester(Loggin.Message):
         
         if pars!=None:
             if pars[0]!=None:
+                print("Fixing Prefactor")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Prefactor').setScale(1e-11)
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Prefactor').setValue(pars[0]/1e-11)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Prefactor').setBounds(pars[0]/1e-11,pars[0]/1e-11)
             if pars[1]!=None:
+                print("Fixing Index1")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setScale(pars[1])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setFree(0)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setBounds(pars[1],pars[1])
             if pars[2]!=None:
-                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setScale(pars[2])
-                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setFree(0)
+                print("Fixing Index2")
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index2').setScale(pars[2])
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index2').setFree(0)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index2').setBounds(pars[2],pars[2])
             if pars[3]!=None:
+                print("Fixing Cutoff")
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Cutoff').setScale(pars[3])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Cutoff').setFree(0)
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Cutoff').setBounds(pars[3],pars[3])
 

--- a/enrico/testModel.py
+++ b/enrico/testModel.py
@@ -61,7 +61,7 @@ class ModelTester(Loggin.Message):
         self._printResults()
 
     def TestModelFromFile(self,inputfile):
-        """ Set model and pars from file """
+        """ Set model and pars from file (test only a custom model) """
         with open(inputfile,'r') as r:
             content = r.read().rstrip().split(",")
             model = content[0]
@@ -78,11 +78,15 @@ class ModelTester(Loggin.Message):
                     try: pars[k] = float(pars[k])
                     except: pars[k]=None
                 
+                # Reduce the list of possible models to the current one
+                self.modellist = [model]
+                
                 print("Using model %s with parameters %s" %(str(model), str(pars)))
                 self.Results[model] = self.RunAFit(self.config["target"]["name"],model,pars)
                 Dumpfile.write(model + '\t' + str(self.Results[model]) + '\n')
                 Dumpfile.close()
-                self._printResults()
+                print("%s Log(Like) = %s" %(model,self.Results[model]))
+                #self._printResults()
 
     def RunAFit(self,srcname,model,pars=None):
         self.info("Computing loglike value for "+model)
@@ -189,9 +193,9 @@ class ModelTester(Loggin.Message):
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setScale(pars[1])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setFree(0)
             if pars[2]!=None:
-                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setScale(pars[1])
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setScale(pars[2])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Index1').setFree(0)
             if pars[3]!=None:
-                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Cutoff').setScale(pars[2])
+                self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Cutoff').setScale(pars[3])
                 self.Fit.logLike.getSource(name).getSrcFuncs()['Spectrum'].getParam('Cutoff').setFree(0)
 

--- a/enrico/testModel.py
+++ b/enrico/testModel.py
@@ -120,14 +120,8 @@ class ModelTester(Loggin.Message):
         Dumpfile.close()
 
     def RunAFit(self,srcname,model,pars=None):
-        # Freezing some parameters to accelerate the LRT. 
-        print("Freezing not interesting model parameters")
-        for i in range(len(self.Fit.model.params)):
-            if self.Fit.model[i].isFree():
-                self.Fit.freeze(i)
-        
+        # Compute the loglike for the current model for the given parameter set.
         self.info("Computing loglike value for "+model)
-        #self._GenFit()
         self.Fit.logLike.getSource(srcname).setSpectrum(model)
         
         if (pars==None):


### PR DESCRIPTION
Add a macro that computes the 'likelihood' for a given model
- Based on the testmodel macro, but with different goals and a bit more flexibility regarding the parameters to use. 
- The aim was to be able to compare likelihoods of models given by external software and compute their LRT. 
- Allow the possibility to specify AppLC radius (more flexibility might come at a later commit).