### PR TITLE
new option in cfg file: ltcube and minos

### DIFF
--- a/enrico/config/default.conf
+++ b/enrico/config/default.conf
@@ -20,6 +20,7 @@ Submit = option('yes', 'no', default='no')
 	event = string(default=events.lis)
 	xml = string(default=model.xml)
 	tag = string(default='')
+    ltcube = string(default='')
 
 [environ]
 	# Analysis environment configuration
@@ -104,6 +105,8 @@ Submit = option('yes', 'no', default='no')
 	FrozenSpectralIndex = float(default=0, min=0, max=5)  
 	#Use the summed likelihood method
 	SummedLike = option('yes', 'no', default='no')
+    # Calculate MINOS errors?
+    minos = option('yes', 'no', default='yes')
 
 
 [UpperLimit]
@@ -186,8 +189,8 @@ Submit = option('yes', 'no', default='no')
 	rad = float(default=1)
 	# list of sources 
 	srclist = string(default="")
-        # number of photons to print
-        numberPhoton = integer(default=10)
+    # number of photons to print
+    numberPhoton = integer(default=10)
 
 [Contours]
 	parname1 = string(default="Prefactor")

--- a/enrico/energybin.py
+++ b/enrico/energybin.py
@@ -53,6 +53,9 @@ def PrepareEbin(Fit, FitRunner):
     #Replace the evt file with the fits file produced before
     #in order to speed up the production of the fits files
     config['file']['event'] = FitRunner.obs.eventfile
+    # use ltcube from global fit to speed up analysis
+    if config['file']['ltcube'] == "":
+        config['file']['ltcube'] = FitRunner.obs.Cubename
     #update the config to allow the fit in energy bins
     config['UpperLimit']['envelope'] = 'no' 
     config['Ebin']['NumEnergyBins'] = '0'#no new bin in energy!

--- a/enrico/energybin.py
+++ b/enrico/energybin.py
@@ -54,8 +54,7 @@ def PrepareEbin(Fit, FitRunner):
     #in order to speed up the production of the fits files
     config['file']['event'] = FitRunner.obs.eventfile
     # use ltcube from global fit to speed up analysis
-    if config['file']['ltcube'] == "":
-        config['file']['ltcube'] = FitRunner.obs.Cubename
+    config['file']['ltcube'] = FitRunner.obs.Cubename
     #update the config to allow the fit in energy bins
     config['UpperLimit']['envelope'] = 'no' 
     config['Ebin']['NumEnergyBins'] = '0'#no new bin in energy!

--- a/enrico/fitmaker.py
+++ b/enrico/fitmaker.py
@@ -54,8 +54,11 @@ class FitMaker(Loggin.Message):
             self.obs.DiffResps()#run gtdiffresp
         self._log('gtbin', 'Create a count map')
         self.obs.Gtbin()
-        self._log('gtltcube', 'Make live time cube')#run gtexpcube
-        self.obs.ExpCube()
+        if self.config["file"]["ltcube"] == "":
+            self._log('gtltcube', 'Make live time cube')#run gtexpcube
+            self.obs.ExpCube()
+        else:
+            self.obs.Cubename = self.config["file"]["ltcube"]
 
         #Choose between the binned of the unbinned analysis
         if self.config['analysis']['likelihood'] == 'binned': #binned analysis chain
@@ -204,7 +207,8 @@ class FitMaker(Loggin.Message):
             Scale = spectrum.getParam(par).getScale()
             Result[par] = ParValue * Scale
             Result['d'+par] = ParError * Scale
-            if ParError>0: # Compute MINOS errors for relevent parameters  Fit.Ts(self.obs.srcname) > 5 and
+            # Compute MINOS errors for relevent parameters  Fit.Ts(self.obs.srcname) > 5 and
+            if ParError>0 and self.config['Spectrum']['minos'] == 'yes':
                 try:
                     MinosErrors = Fit.minosError(self.obs.srcname, par)
                     if self.config['verbose'] == 'yes' :
@@ -218,8 +222,8 @@ class FitMaker(Loggin.Message):
                           (ParValue, ParError, Scale))
             else:
                 if self.config['verbose'] == 'yes' :
-                    print(par+" :  %2.2f   %2.0e" %
-                      (ParValue, Scale))
+                    print(par+" :  %2.2f +/-  %2.2f  %2.0e" %
+                      (ParValue, ParError, Scale))
 
         try: # get covariance matrix
             if self.config['verbose'] == 'yes' :

--- a/enrico/fitmaker.py
+++ b/enrico/fitmaker.py
@@ -54,11 +54,11 @@ class FitMaker(Loggin.Message):
             self.obs.DiffResps()#run gtdiffresp
         self._log('gtbin', 'Create a count map')
         self.obs.Gtbin()
+        self._log('gtltcube', 'Make live time cube')#run gtexpcube
         if self.config["file"]["ltcube"] == "":
-            self._log('gtltcube', 'Make live time cube')#run gtexpcube
             self.obs.ExpCube()
         else:
-            self.obs.Cubename = self.config["file"]["ltcube"]
+            print("Using live time cube from %s" % self.config["file"]["ltcube"])
 
         #Choose between the binned of the unbinned analysis
         if self.config['analysis']['likelihood'] == 'binned': #binned analysis chain

--- a/enrico/gtfunction.py
+++ b/enrico/gtfunction.py
@@ -33,6 +33,8 @@ class Observation:
         #Fits files
         self.eventfile = folder+'/'+self.srcname+inttag+"_Evt.fits"
         self.Cubename  = folder+'/'+self.srcname+inttag+"_ltCube.fits"
+        if Configuration['file']['ltcube'] != "":
+            self.Cubename = Configuration['file']['ltcube']
         self.Mapname   = folder+'/'+self.srcname+inttag+"_ExpMap.fits"
         self.BinnedMapfile = folder+'/'+self.srcname+inttag+"_BinnedMap.fits"
         self.cmapfile  = folder+'/'+self.srcname+inttag+"_CountMap.fits"


### PR DESCRIPTION
I know that there is a very similar request, but i think it is worth reconsidering.
 - New option 'ltcube' introduced in the cfg file. Now you can specify a live time cube that will be used for the analysis.
 - For the analysis in the different energy bins, enrico now uses the ltcube from the global fit instead of producing the same file x times. This was very easy to implement with the new ltcube option.
 - New option 'minos' introduced in the cfg file. Now you can choose if you want to calculate MINOS errors or not. I found that depending on your analysis it can take a very long time, so i thought it would be nice to have the possibility to skip it.
Cheers,
David