### PR TITLE
Fix #109 + Fix 1-bin time-bins file

### DIFF
--- a/enrico/RunGTlike.py
+++ b/enrico/RunGTlike.py
@@ -180,10 +180,6 @@ def run(infile):
     # create all the fit files and run gtlike
     FitRunner.PerformFit(Fit)
 
-    #Get and dump the target specific results
-    Result = FitRunner.GetAndPrintResults(Fit)
-    utils.DumpResult(Result, config)
-
     #plot the SED and model map if possible and asked
     if float(config['UpperLimit']['TSlimit']) < Fit.Ts(config['target']['name']):
         if config['Spectrum']['ResultPlots'] == 'yes':
@@ -212,8 +208,10 @@ def run(infile):
             if varscale is not None:
                 spectrum.getParam(varscale).setValue(sedresult.decE)
                 FitRunner.PerformFit(Fit)
-
-
+            
+    #Get and dump the target specific results
+    Result = FitRunner.GetAndPrintResults(Fit)
+    utils.DumpResult(Result, config)
 
     if config['Spectrum']['ResultPlots'] == 'yes' :
         outXml = utils._dump_xml(config)

--- a/enrico/fitmaker.py
+++ b/enrico/fitmaker.py
@@ -97,7 +97,7 @@ class FitMaker(Loggin.Message):
 
         #create a unbinnedAnalysis object
         if self.config['analysis']['likelihood'] == 'unbinned':
-            Obs = UnbinnedObs(self.obs.eventfile,
+            Obs = UnbinnedObs(self.obs.mktimefile,
                               self.obs.ft2,
                               expMap=self.obs.Mapname,
                               expCube=self.obs.Cubename,

--- a/enrico/gtfunction.py
+++ b/enrico/gtfunction.py
@@ -262,8 +262,6 @@ class Observation:
             outfile = self.eventfile.replace('.fits','_{}'.format(numbin))
             self._RunMktime(selstr,outfile,'no')
             eventlist.append(outfile+'\n')
-            maketime['outfile'] = outfile
-            maketime.run()
 
         evlist_filename = self.eventfile.replace('.fits','.list')
         with open(evlist_filename,'w') as evlistfile:
@@ -286,18 +284,20 @@ class Observation:
     def MkTime(self):
         import os.path
         """compute GTI"""
+        ## Maketime does not listen to clobber variables
+        if (self.clobber=="no" and os.path.isfile(self.mktimefile)):
+            return(0)
+
         if self.Configuration['time']['file'] != '':
             self.time_selection()
         selstr = self.Configuration['analysis']['filter']
         outfile = self.mktimefile+".tmp"
-        ## Maketime does not listen to clobber variables
-        if (not os.path.exists(outfile) or self.clobber):
-            self._RunMktime(selstr,outfile,self.Configuration['analysis']['roicut'])
-            os.system("mv "+outfile+" "+self.mktimefile)
+        self._RunMktime(selstr,outfile,self.Configuration['analysis']['roicut'])
+        os.system("mv "+outfile+" "+self.mktimefile)
 
     def _RunMktime(self,selstr,outfile,roicut):
         """run gtmktime tool"""
-        if (self.clobber=="no" and os.path.isfile(self.diffrspflag)):
+        if (self.clobber=="no" and os.path.isfile(self.mktimefile)):
             #print("File exists and clobber is False")
             return(0)
         maketime['scfile']  = self.ft2

--- a/enrico/plotting.py
+++ b/enrico/plotting.py
@@ -42,14 +42,13 @@ class Result(Loggin.Message):
 
     def GetDecorrelationEnergy(self,par):
         self.E, self.SED = self.MakeSED(par)
-        self.Err = self.MakeSEDError(par)
-        for i in xrange(par.N):
-          if self.Err[i]/self.SED[i] == min(self.Err/self.SED):
-            self.decE       = self.E[i]
-            self.decFlux    = self.SED[i]/self.E[i]**2*ERG_TO_MEV
-            self.decFluxerr = self.Err[i]/self.E[i]**2*ERG_TO_MEV
-            self.decSED     = self.SED[i]
-            self.decSEDerr  = self.Err[i]
+        self.Err         = self.MakeSEDError(par)
+        i=np.argmin(self.Err/self.SED)
+        self.decE       = self.E[i]
+        self.decFlux    = self.SED[i]/self.E[i]**2*ERG_TO_MEV
+        self.decFluxerr = self.Err[i]/self.E[i]**2*ERG_TO_MEV
+        self.decSED     = self.SED[i]
+        self.decSEDerr  = self.Err[i]
 
     def _DumpSED(self,par):
         """Save the energy, E2.dN/dE, and corresponding  error in an ascii file

--- a/enrico/utils.py
+++ b/enrico/utils.py
@@ -276,6 +276,8 @@ def time_selection_string(config,numbin0):
 
     selstr=''
     last=True
+
+    if np.shape(bins)==(2,): bins = [bins]
     for numbin in range(numbin0,len(bins)):
         tbin=bins[numbin]
         selstr+='((START>{0:.0f})&&(STOP<{1:.0f}))||'.format(tbin[0],tbin[1])


### PR DESCRIPTION
There's an issue with time-bins file when it only contains 1 time bin (START STOP)

It is incorrectly interpreted as a (2,) numpy array, while it should be (2,1) so that bins[0] retrieves the [START,STOP] tuple, not only the START float.