### PR TITLE
Minor fixes, matplotlib style, gtpsf and Bayesian Blocks

### DIFF
--- a/enrico/RunGTlike.py
+++ b/enrico/RunGTlike.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-import os,os.path,math
+import os,glob,os.path,math
 from enrico import utils
 from enrico.gtfunction import Observation
 from enrico.fitmaker import FitMaker
 import Loggin
 import SummedLikelihood
+from enrico.xml_model import XmlMaker
 from enrico.extern.configobj import ConfigObj
 from utils import hasKey, isKey, typeirfs
 
@@ -31,8 +32,8 @@ def GenAnalysisObjects(config, verbose = 1, xmlfile =""):
     SummedLike = config['Spectrum']['SummedLike']
     folder = config['out']
 
-    # If there is no xml file, create it and print a warning
-    if (not os.path.isfile(config['file']['xml'])):
+    # If there are no xml file, create it and print a warning
+    if (glob.glob("%s*.xml" %config['file']['xml'].replace('.xml','')) is []):
         mes.warning("Xml not found, creating one for the given config %s" %config['file']['xml'])
         XmlMaker(config)
 
@@ -78,6 +79,7 @@ def GenAnalysisObjects(config, verbose = 1, xmlfile =""):
     if isKey(config['ComponentAnalysis'],'EDISP') == 'yes':
         evtnum = [64,128,256,521]
     oldxml = config['file']['xml']
+    print(oldxml)
     for k,evt in enumerate(evtnum):
         config['event']['evtype'] = evt
         config["file"]["xml"] = oldxml.replace(".xml","_"+typeirfs[evt]+".xml").replace("_.xml",".xml")

--- a/enrico/appertureLC.py
+++ b/enrico/appertureLC.py
@@ -8,6 +8,8 @@ from enrico.gtfunction import Observation
 from enrico.config import get_config
 from enrico import environ
 from enrico import utils
+import matplotlib
+matplotlib.rc('text', usetex=True)
 import matplotlib.pyplot as plt
 
 def AppLC(infile):

--- a/enrico/config/default.conf
+++ b/enrico/config/default.conf
@@ -130,6 +130,8 @@ Submit = option('yes', 'no', default='no')
 	#Index for the power law. Left free to vary if 0
 	SpectralIndex =  float(default=2, min=0, max=5)
 	MakeConfFile = option('yes', 'no', default='yes')c
+	#Bayesian blocks 
+	BayesianBlocks = option('yes', 'no', default='no')
 	#Compute Variability index as in the 2FGL. 
 	ComputeVarIndex = option('yes', 'no', default='yes')
 	#Compute an UL if the TS of the sources is <TSLightCurve

--- a/enrico/extern/astropy_bayesian_blocks.py
+++ b/enrico/extern/astropy_bayesian_blocks.py
@@ -1,0 +1,515 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Bayesian Blocks for Time Series Analysis
+========================================
+
+Dynamic programming algorithm for solving a piecewise-constant model for
+various datasets. This is based on the algorithm presented in Scargle
+et al 2012 [1]_. This code was ported from the astroML project [2]_.
+
+Applications include:
+
+- finding an optimal histogram with adaptive bin widths
+- finding optimal segmentation of time series data
+- detecting inflection points in the rate of event data
+
+The primary interface to these routines is the :func:`bayesian_blocks`
+function. This module provides fitness functions suitable for three types
+of data:
+
+- Irregularly-spaced event data via the :class:`Events` class
+- Regularly-spaced event data via the :class:`RegularEvents` class
+- Irregularly-spaced point measurements via the :class:`PointMeasures` class
+
+For more fine-tuned control over the fitness functions used, it is possible
+to define custom :class:`FitnessFunc` classes directly and use them with
+the :func:`bayesian_blocks` routine.
+
+One common application of the Bayesian Blocks algorithm is the determination
+of optimal adaptive-width histogram bins. This uses the same fitness function
+as for irregularly-spaced time series events. The easiest interface for
+creating Bayesian Blocks histograms is the :func:`astropy.stats.histogram`
+function.
+
+References
+----------
+.. [1] http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
+.. [2] http://astroML.org/ https://github.com//astroML/astroML/
+"""
+
+import warnings
+
+import numpy as np
+import types
+#from funcsigs import signature
+from inspect import getargspec
+
+# TODO: implement other fitness functions from appendix B of Scargle 2012
+
+__all__ = ['FitnessFunc', 'Events', 'RegularEvents', 'PointMeasures',
+           'bayesian_blocks']
+
+
+def bayesian_blocks(t, x=None, sigma=None,
+                    fitness='events', **kwargs):
+    r"""Compute optimal segmentation of data with Scargle's Bayesian Blocks
+
+    This is a flexible implementation of the Bayesian Blocks algorithm
+    described in Scargle 2012 [1]_.
+
+    Parameters
+    ----------
+    t : array_like
+        data times (one dimensional, length N)
+    x : array_like (optional)
+        data values
+    sigma : array_like or float (optional)
+        data errors
+    fitness : str or object
+        the fitness function to use for the model.
+        If a string, the following options are supported:
+
+        - 'events' : binned or unbinned event data.  Arguments are ``gamma``,
+          which gives the slope of the prior on the number of bins, or
+          ``ncp_prior``, which is :math:`-\ln({\tt gamma})`.
+        - 'regular_events' : non-overlapping events measured at multiples of a
+          fundamental tick rate, ``dt``, which must be specified as an
+          additional argument.  Extra arguments are ``p0``, which gives the
+          false alarm probability to compute the prior, or ``gamma``, which
+          gives the slope of the prior on the number of bins, or ``ncp_prior``,
+          which is :math:`-\ln({\tt gamma})`.
+        - 'measures' : fitness for a measured sequence with Gaussian errors.
+          Extra arguments are ``p0``, which gives the false alarm probability
+          to compute the prior, or ``gamma``, which gives the slope of the
+          prior on the number of bins, or ``ncp_prior``, which is
+          :math:`-\ln({\tt gamma})`.
+
+        In all three cases, if more than one of ``p0``, ``gamma``, and
+        ``ncp_prior`` is chosen, ``ncp_prior`` takes precedence over ``gamma``
+        which takes precedence over ``p0``.
+
+        Alternatively, the fitness parameter can be an instance of
+        :class:`FitnessFunc` or a subclass thereof.
+
+    **kwargs :
+        any additional keyword arguments will be passed to the specified
+        :class:`FitnessFunc` derived class.
+
+    Returns
+    -------
+    edges : ndarray
+        array containing the (N+1) edges defining the N bins
+
+    Examples
+    --------
+    Event data:
+
+    >>> t = np.random.normal(size=100)
+    >>> edges = bayesian_blocks(t, fitness='events', p0=0.01)
+
+    Event data with repeats:
+
+    >>> t = np.random.normal(size=100)
+    >>> t[80:] = t[:20]
+    >>> edges = bayesian_blocks(t, fitness='events', p0=0.01)
+
+    Regular event data:
+
+    >>> dt = 0.05
+    >>> t = dt * np.arange(1000)
+    >>> x = np.zeros(len(t))
+    >>> x[np.random.randint(0, len(t), len(t) // 10)] = 1
+    >>> edges = bayesian_blocks(t, x, fitness='regular_events', dt=dt)
+
+    Measured point data with errors:
+
+    >>> t = 100 * np.random.random(100)
+    >>> x = np.exp(-0.5 * (t - 50) ** 2)
+    >>> sigma = 0.1
+    >>> x_obs = np.random.normal(x, sigma)
+    >>> edges = bayesian_blocks(t, x_obs, sigma, fitness='measures')
+
+    References
+    ----------
+    .. [1] Scargle, J et al. (2012)
+       http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
+
+    See Also
+    --------
+    astropy.stats.histogram : compute a histogram using bayesian blocks
+    """
+    FITNESS_DICT = {'events': Events,
+                    'regular_events': RegularEvents,
+                    'measures': PointMeasures}
+    fitness = FITNESS_DICT.get(fitness, fitness)
+    if isinstance(fitness, (types.TypeType, types.ClassType)) and issubclass(fitness, FitnessFunc):
+        #if (type(fitness) is type or str(type(fitness)) is '<type classobj>') and issubclass(fitness, FitnessFunc):
+        fitfunc = fitness(**kwargs)
+    elif isinstance(fitness, FitnessFunc):
+        fitfunc = fitness
+    else:
+        raise ValueError("fitness parameter not understood")
+
+    return fitfunc.fit(t, x, sigma)
+
+
+class FitnessFunc(object):
+    """Base class for bayesian blocks fitness functions
+
+    Derived classes should overload the following method:
+
+    ``fitness(self, **kwargs)``:
+      Compute the fitness given a set of named arguments.
+      Arguments accepted by fitness must be among ``[T_k, N_k, a_k, b_k, c_k]``
+      (See [1]_ for details on the meaning of these parameters).
+
+    Additionally, other methods may be overloaded as well:
+
+    ``__init__(self, **kwargs)``:
+      Initialize the fitness function with any parameters beyond the normal
+      ``p0`` and ``gamma``.
+
+    ``validate_input(self, t, x, sigma)``:
+      Enable specific checks of the input data (``t``, ``x``, ``sigma``)
+      to be performed prior to the fit.
+
+    ``compute_ncp_prior(self, N)``: If ``ncp_prior`` is not defined explicitly,
+      this function is called in order to define it before fitting. This may be
+      calculated from ``gamma``, ``p0``, or whatever method you choose.
+
+    ``p0_prior(self, N)``:
+      Specify the form of the prior given the false-alarm probability ``p0``
+      (See [1]_ for details).
+
+    For examples of implemented fitness functions, see :class:`Events`,
+    :class:`RegularEvents`, and :class:`PointMeasures`.
+
+    References
+    ----------
+    .. [1] Scargle, J et al. (2012)
+       http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
+    """
+    def __init__(self, p0=0.05, gamma=None, ncp_prior=None):
+        self.p0 = p0
+        self.gamma = gamma
+        self.ncp_prior = ncp_prior
+
+    def validate_input(self, t, x=None, sigma=None):
+        """Validate inputs to the model.
+
+        Parameters
+        ----------
+        t : array_like
+            times of observations
+        x : array_like (optional)
+            values observed at each time
+        sigma : float or array_like (optional)
+            errors in values x
+
+        Returns
+        -------
+        t, x, sigma : array_like, float or None
+            validated and perhaps modified versions of inputs
+        """
+        # validate array input
+        t = np.asarray(t, dtype=float)
+        if x is not None:
+            x = np.asarray(x)
+        if sigma is not None:
+            sigma = np.asarray(sigma)
+
+        # find unique values of t
+        t = np.array(t)
+        if t.ndim != 1:
+            raise ValueError("t must be a one-dimensional array")
+        unq_t, unq_ind, unq_inv = np.unique(t, return_index=True,
+                                            return_inverse=True)
+
+        # if x is not specified, x will be counts at each time
+        if x is None:
+            if sigma is not None:
+                raise ValueError("If sigma is specified, x must be specified")
+            else:
+                sigma = 1
+
+            if len(unq_t) == len(t):
+                x = np.ones_like(t)
+            else:
+                x = np.bincount(unq_inv)
+
+            t = unq_t
+
+        # if x is specified, then we need to simultaneously sort t and x
+        else:
+            # TODO: allow broadcasted x?
+            x = np.asarray(x)
+            if x.shape not in [(), (1,), (t.size,)]:
+                raise ValueError("x does not match shape of t")
+            x += np.zeros_like(t)
+
+            if len(unq_t) != len(t):
+                raise ValueError("Repeated values in t not supported when "
+                                 "x is specified")
+            t = unq_t
+            x = x[unq_ind]
+
+        # verify the given sigma value
+        if sigma is None:
+            sigma = 1
+        else:
+            sigma = np.asarray(sigma)
+            if sigma.shape not in [(), (1,), (t.size,)]:
+                raise ValueError('sigma does not match the shape of x')
+
+        return t, x, sigma
+
+    def fitness(self, **kwargs):
+        raise NotImplementedError()
+
+    def p0_prior(self, N):
+        """
+        Empirical prior, parametrized by the false alarm probability ``p0``
+        See  eq. 21 in Scargle (2012)
+
+        Note that there was an error in this equation in the original Scargle
+        paper (the "log" was missing). The following corrected form is taken
+        from https://arxiv.org/abs/1304.2818
+        """
+        return 4 - np.log(73.53 * self.p0 * (N ** -0.478))
+
+    # the fitness_args property will return the list of arguments accepted by
+    # the method fitness().  This allows more efficient computation below.
+    @property
+    def _fitness_args(self):
+        return getargspec(self.fitness)[0]
+        #return signature(self.fitness).parameters.keys()
+
+    def compute_ncp_prior(self, N):
+        """
+        If ``ncp_prior`` is not explicitly defined, compute it from ``gamma``
+        or ``p0``.
+        """
+        if self.ncp_prior is not None:
+            return self.ncp_prior
+        elif self.gamma is not None:
+            return -np.log(self.gamma)
+        elif self.p0 is not None:
+            return self.p0_prior(N)
+        else:
+            raise ValueError("``ncp_prior`` is not defined, and cannot compute "
+                             "it as neither ``gamma`` nor ``p0`` is defined.")
+
+    def fit(self, t, x=None, sigma=None):
+        """Fit the Bayesian Blocks model given the specified fitness function.
+
+        Parameters
+        ----------
+        t : array_like
+            data times (one dimensional, length N)
+        x : array_like (optional)
+            data values
+        sigma : array_like or float (optional)
+            data errors
+
+        Returns
+        -------
+        edges : ndarray
+            array containing the (M+1) edges defining the M optimal bins
+        """
+        t, x, sigma = self.validate_input(t, x, sigma)
+
+        # compute values needed for computation, below
+        if 'a_k' in self._fitness_args:
+            ak_raw = np.ones_like(x) / sigma ** 2
+        if 'b_k' in self._fitness_args:
+            bk_raw = x / sigma ** 2
+        if 'c_k' in self._fitness_args:
+            ck_raw = x * x / sigma ** 2
+
+        # create length-(N + 1) array of cell edges
+        edges = np.concatenate([t[:1],
+                                0.5 * (t[1:] + t[:-1]),
+                                t[-1:]])
+        block_length = t[-1] - edges
+
+        # arrays to store the best configuration
+        N = len(t)
+        best = np.zeros(N, dtype=float)
+        last = np.zeros(N, dtype=int)
+
+        # Compute ncp_prior if not defined
+        if self.ncp_prior is None:
+            ncp_prior = self.compute_ncp_prior(N)
+        # ----------------------------------------------------------------
+        # Start with first data cell; add one cell at each iteration
+        # ----------------------------------------------------------------
+        for R in range(N):
+            # Compute fit_vec : fitness of putative last block (end at R)
+            kwds = {}
+
+            # T_k: width/duration of each block
+            if 'T_k' in self._fitness_args:
+                kwds['T_k'] = block_length[:R + 1] - block_length[R + 1]
+
+            # N_k: number of elements in each block
+            if 'N_k' in self._fitness_args:
+                kwds['N_k'] = np.cumsum(x[:R + 1][::-1])[::-1]
+
+            # a_k: eq. 31
+            if 'a_k' in self._fitness_args:
+                kwds['a_k'] = 0.5 * np.cumsum(ak_raw[:R + 1][::-1])[::-1]
+
+            # b_k: eq. 32
+            if 'b_k' in self._fitness_args:
+                kwds['b_k'] = - np.cumsum(bk_raw[:R + 1][::-1])[::-1]
+
+            # c_k: eq. 33
+            if 'c_k' in self._fitness_args:
+                kwds['c_k'] = 0.5 * np.cumsum(ck_raw[:R + 1][::-1])[::-1]
+
+            # evaluate fitness function
+            fit_vec = self.fitness(**kwds)
+
+            A_R = fit_vec - ncp_prior
+            A_R[1:] += best[:R]
+
+            i_max = np.argmax(A_R)
+            last[R] = i_max
+            best[R] = A_R[i_max]
+
+        # ----------------------------------------------------------------
+        # Now find changepoints by iteratively peeling off the last block
+        # ----------------------------------------------------------------
+        change_points = np.zeros(N, dtype=int)
+        i_cp = N
+        ind = N
+        while True:
+            i_cp -= 1
+            change_points[i_cp] = ind
+            if ind == 0:
+                break
+            ind = last[ind - 1]
+        change_points = change_points[i_cp:]
+
+        return edges[change_points]
+
+
+class Events(FitnessFunc):
+    r"""Bayesian blocks fitness for binned or unbinned events
+
+    Parameters
+    ----------
+    p0 : float (optional)
+        False alarm probability, used to compute the prior on
+        :math:`N_{\rm blocks}` (see eq. 21 of Scargle 2012). For the Events
+        type data, ``p0`` does not seem to be an accurate representation of the
+        actual false alarm probability. If you are using this fitness function
+        for a triggering type condition, it is recommended that you run
+        statistical trials on signal-free noise to determine an appropriate
+        value of ``gamma`` or ``ncp_prior`` to use for a desired false alarm
+        rate.
+    gamma : float (optional)
+        If specified, then use this gamma to compute the general prior form,
+        :math:`p \sim {\tt gamma}^{N_{\rm blocks}}`.  If gamma is specified, p0
+        is ignored.
+    ncp_prior : float (optional)
+        If specified, use the value of ``ncp_prior`` to compute the prior as
+        above, using the definition :math:`{\tt ncp\_prior} = -\ln({\tt
+        gamma})`.
+        If ``ncp_prior`` is specified, ``gamma`` and ``p0`` is ignored.
+    """
+    def __init__(self, p0=0.05, gamma=None, ncp_prior=None):
+        if p0 is not None and gamma is None and ncp_prior is None:
+            warnings.warn('p0 does not seem to accurately represent the false '
+                          'positive rate for event data. It is highly '
+                          'recommended that you run random trials on signal-'
+                          'free noise to calibrate ncp_prior to achieve a '
+                          'desired false positive rate.', AstropyUserWarning)
+        super().__init__(p0, gamma, ncp_prior)
+
+    def fitness(self, N_k, T_k):
+        # eq. 19 from Scargle 2012
+        return N_k * (np.log(N_k) - np.log(T_k))
+
+    def validate_input(self, t, x, sigma):
+        t, x, sigma = super().validate_input(t, x, sigma)
+        if x is not None and np.any(x % 1 > 0):
+            raise ValueError("x must be integer counts for fitness='events'")
+        return t, x, sigma
+
+
+class RegularEvents(FitnessFunc):
+    r"""Bayesian blocks fitness for regular events
+
+    This is for data which has a fundamental "tick" length, so that all
+    measured values are multiples of this tick length.  In each tick, there
+    are either zero or one counts.
+
+    Parameters
+    ----------
+    dt : float
+        tick rate for data
+    p0 : float (optional)
+        False alarm probability, used to compute the prior on :math:`N_{\rm
+        blocks}` (see eq. 21 of Scargle 2012). If gamma is specified, p0 is
+        ignored.
+    ncp_prior : float (optional)
+        If specified, use the value of ``ncp_prior`` to compute the prior as
+        above, using the definition :math:`{\tt ncp\_prior} = -\ln({\tt
+        gamma})`.  If ``ncp_prior`` is specified, ``gamma`` and ``p0`` are
+        ignored.
+    """
+    def __init__(self, dt, p0=0.05, gamma=None, ncp_prior=None):
+        self.dt = dt
+        super().__init__(p0, gamma, ncp_prior)
+
+    def validate_input(self, t, x, sigma):
+        t, x, sigma = super().validate_input(t, x, sigma)
+        if not np.all((x == 0) | (x == 1)):
+            raise ValueError("Regular events must have only 0 and 1 in x")
+        return t, x, sigma
+
+    def fitness(self, T_k, N_k):
+        # Eq. 75 of Scargle 2012
+        M_k = T_k / self.dt
+        N_over_M = N_k / M_k
+
+        eps = 1E-8
+        if np.any(N_over_M > 1 + eps):
+            warnings.warn('regular events: N/M > 1.  '
+                          'Is the time step correct?', AstropyUserWarning)
+
+        one_m_NM = 1 - N_over_M
+        N_over_M[N_over_M <= 0] = 1
+        one_m_NM[one_m_NM <= 0] = 1
+
+        return N_k * np.log(N_over_M) + (M_k - N_k) * np.log(one_m_NM)
+
+
+class PointMeasures(FitnessFunc):
+    r"""Bayesian blocks fitness for point measures
+
+    Parameters
+    ----------
+    p0 : float (optional)
+        False alarm probability, used to compute the prior on :math:`N_{\rm
+        blocks}` (see eq. 21 of Scargle 2012). If gamma is specified, p0 is
+        ignored.
+    ncp_prior : float (optional)
+        If specified, use the value of ``ncp_prior`` to compute the prior as
+        above, using the definition :math:`{\tt ncp\_prior} = -\ln({\tt
+        gamma})`.  If ``ncp_prior`` is specified, ``gamma`` and ``p0`` are
+        ignored.
+    """
+    def __init__(self, p0=0.05, gamma=None, ncp_prior=None):
+        super(PointMeasures, self).__init__(p0, gamma, ncp_prior)
+
+    def fitness(self, a_k, b_k):
+        # eq. 41 from Scargle 2012
+        return (b_k * b_k) / (4 * a_k)
+
+    def validate_input(self, t, x, sigma):
+        if x is None:
+            raise ValueError("x must be specified for point measures")
+        return super(PointMeasures, self).validate_input(t, x, sigma)

--- a/enrico/fitmaker.py
+++ b/enrico/fitmaker.py
@@ -66,8 +66,10 @@ class FitMaker(Loggin.Message):
             self.obs.DiffResps()#run gtdiffresp
         self._log('gtbin', 'Create a count map')
         self.obs.Gtbin()
-        self._log('gtltcube', 'Make live time cube')#run gtexpcube
+        self._log('gtltcube', 'Make live time cube')#run gtltcube
         self.obs.ExpCube()
+        self.info('Compute the psf')#run gtpsf
+        self.obs.GtPSF()
 
         #Choose between the binned of the unbinned analysis
         if self.config['analysis']['likelihood'] == 'binned': #binned analysis chain
@@ -294,9 +296,9 @@ class FitMaker(Loggin.Message):
         self.obs.GtExposure()
         Exposure = np.sum(spfile[1].data.field("EXPOSURE"))
 
-        ###
-        self.info('Compute the psf')#run gtexposure
-        self.obs.GtPSF()
+        ### Run it in any case (useful for instance for the DL3)
+        #self.info('Compute the psf')#run gtpsf
+        #self.obs.GtPSF()
 
         ccube = pyfits.open(self.obs.ccube)
         psfres = pyfits.open(self.obs.psf)

--- a/enrico/lightcurve.py
+++ b/enrico/lightcurve.py
@@ -3,6 +3,10 @@ from math import sqrt
 import numpy as np
 import scipy.optimize
 from scipy.stats import chi2
+import matplotlib
+matplotlib.use('Agg')
+matplotlib.rc('font', **{'family': 'serif', 'serif': ['Computer Modern'], 'size': 15})
+matplotlib.rc('text', usetex=True)
 import matplotlib.pyplot as plt
 from enrico import utils
 from enrico import plotting
@@ -12,6 +16,7 @@ from enrico.constants import LightcurvePath,FoldedLCPath
 from enrico.submit import call
 from enrico.RunGTlike import run, GenAnalysisObjects
 from enrico import Loggin
+from enrico.plotting import plot_errorbar_withuls
 
 pol0 = lambda x,p1: p1*x
 pol1 = lambda x,p1,p2: p1+p2*x
@@ -221,8 +226,6 @@ class LightCurve(Loggin.Message):
         self._PlotLC(True)
 
     def _PlotLC(self,folded=False):
-
-
         self.info("Reading files produced by enrico")
         LcOutPath = self.LCfolder + self.config['target']['name']
 
@@ -341,8 +344,8 @@ class LightCurve(Loggin.Message):
                         print 
 
                 plt.plot(np.array([0,max(NdN)]),pol1(np.array([0,max(NdN)]),popt[0],popt[1]),'--',color='black')
-                plt.xlabel("Npred/sqrt(Npred)")
-                plt.ylabel(r"Flux/$\Delta$ Flux")
+                plt.xlabel(r"${\rm Npred/\sqrt{Npred}}$")
+                plt.ylabel(r"${\rm Flux/\Delta Flux}$")
                 plt.savefig(LcOutPath+"_Npred.png", dpi=150, facecolor='w', edgecolor='w',
                     orientation='portrait', papertype=None, format=None,
                     transparent=False, bbox_inches=None, pad_inches=0.1,
@@ -353,8 +356,8 @@ class LightCurve(Loggin.Message):
             #plot TS vs Time
             plt.figure()
             plt.ylim(ymin=min(TS)*0.8,ymax=max(TS)*1.2)
-            plt.xlabel("Time")
-            plt.ylabel("Test Statistic")
+            plt.xlabel(r"Time (s)")
+            plt.ylabel(r"Test Statistic")
             plt.errorbar(Time,TS,xerr=TimeErr,fmt='+',color='black',ls='None')
             plt.savefig(LcOutPath+"_TS.png", dpi=150, facecolor='w', edgecolor='w',
                     orientation='portrait', papertype=None, format=None,
@@ -383,11 +386,12 @@ class LightCurve(Loggin.Message):
         # ymin = min(Flux) - max(FluxErr) * 1.3
         # ymax = max(Flux) + max(FluxErr) * 1.3
         plt.figure()
-        plt.xlabel("Time")
-        plt.ylabel("Flux (photon cm^{-2} s^{-1})")
+        plt.xlabel(r"Time (s)")
+        plt.ylabel(r"${\rm Flux\ (photon\ cm^{-2}\ s^{-1})}$")
         # plt.ylim(ymin=ymin,ymax=ymax)
         # plt.xlim(xmin=xmin,xmax=xmax)
-        plt.errorbar(Time,Flux,xerr=TimeErr,yerr=FluxErr,fmt='o',color='black',ls='None',uplims=uplim)
+        #plt.errorbar(Time,Flux,xerr=TimeErr,yerr=FluxErr,fmt='o',color='black',ls='None',uplims=uplim)
+        plot_errorbar_withuls(Time,TimeErr,TimeErr,Flux,FluxErr,FluxErr,uplim)
 
         plt.savefig(LcOutPath+"_LC.png", dpi=150, facecolor='w', edgecolor='w',
                 orientation='portrait', papertype=None, format=None,
@@ -445,9 +449,9 @@ class LightCurve(Loggin.Message):
         """Fit the LC with a constant function an
            print the chi2 and proba"""
         res,_ = scipy.optimize.curve_fit(pol0,x,y,p0=[np.mean(y)],sigma=dy)
-        print res
-        print y
-        print dy
+        #print res
+        #print y
+        #print dy
         cost = np.sum(((pol0(x,res[0])-y)/dy)**2)
         self.info("Fit with a constant function")
         print '\tChi2 = ',cost," NDF = ",len(y)-1

--- a/enrico/lightcurve.py
+++ b/enrico/lightcurve.py
@@ -162,8 +162,6 @@ class LightCurve(Loggin.Message):
                 #run(self.configfile[i])#run in command line
 
 
-
-
     def _MakePhasebin(self):
         """document me """
         self.time_array = np.zeros(self.Nbin*2)
@@ -391,7 +389,7 @@ class LightCurve(Loggin.Message):
         # plt.ylim(ymin=ymin,ymax=ymax)
         # plt.xlim(xmin=xmin,xmax=xmax)
         #plt.errorbar(Time,Flux,xerr=TimeErr,yerr=FluxErr,fmt='o',color='black',ls='None',uplims=uplim)
-        plot_errorbar_withuls(Time,TimeErr,TimeErr,Flux,FluxErr,FluxErr,uplim)
+        plot_errorbar_withuls(Time,TimeErr,TimeErr,Flux,FluxErr,FluxErr,uplim,bblocks=True)
 
         plt.savefig(LcOutPath+"_LC.png", dpi=150, facecolor='w', edgecolor='w',
                 orientation='portrait', papertype=None, format=None,

--- a/enrico/plotting.py
+++ b/enrico/plotting.py
@@ -357,12 +357,13 @@ def PlotSED(config,pars):
 
     #Actually make the plot
     plt.figure()
-    plt.title(pars.PlotName)
+    plt.title(pars.PlotName.split("/")[-1])
+    name = pars.PlotName.split("/")[-1]
     plt.loglog()
 
-    plt.xlabel(r"E [MeV]")
-    plt.ylabel(r"$E^{2}dN/dE [ erg.cm^{-2}.s^{-1} ]$")
-    plt.plot(E,SED,"-r")
+    plt.xlabel(r"$\mathbf{E}\ \mathrm{[MeV]}$",fontsize='x-large')
+    plt.ylabel(r"$\mathbf{E^{2}\ dN/dE}\ \mathrm{[ erg\ cm^{-2} s^{-1} ]}$",fontsize='x-large')
+    plt.plot(E,SED,"-r",label='LAT model')
     plt.plot(ErrorE,ErrorFlux,"-r")
 
     #Plot points
@@ -374,11 +375,37 @@ def PlotSED(config,pars):
     print FluxpointErrm
     print FluxpointErrp
     # plt.errorbar(Epoint, Fluxpoint, xerr=[EpointErrm, EpointErrp], yerr=[FluxpointErrm, FluxpointErrp],fmt='o',color='black',ls='None',uplims=uplim)
-    plt.errorbar(Epoint, Fluxpoint, xerr=[EpointErrm, EpointErrp], yerr=[FluxpointErrm, FluxpointErrp],fmt='o',capsize=0,color='black',ls='None',uplims=uplim)
+    plt.errorbar(Epoint, Fluxpoint, xerr=[EpointErrm, EpointErrp], yerr=[FluxpointErrm, FluxpointErrp],fmt='o',capsize=0,color='black',ls='None',uplims=uplim,label='LAT ebins')
+
+    #Set meaningful axes limits
+    xlim = plt.xlim()
+    ylim = plt.ylim()
+    xlim = (max([20,xlim[0]]),min([2e6,xlim[1]]))
+    ylim = (max([1e-13,ylim[0]]),min([1e-8,ylim[1]]))
+    plt.xlim(xlim)
+    plt.ylim(ylim)
+    # turn them into log10 scale
+    #xticks = plt.xticks()[0]
+    #xticklabels = np.array(np.log10(xticks),dtype=int) 
+    #plt.xticks(xticks,xticklabels)
+    #plt.xlabel('$\mathrm{\log_{10}\mathbf{(Energy)} \\ \\ [MeV]}$')
+    
+    plt.legend(fontsize='small',ncol=1,\
+               loc=3,numpoints=1)#,framealpha=0.75)
+
+
+    #Upper horizontal secondary axis with frequency
+    #Plt2 = plt.twiny()
+    #Plt2.set_xscale('log')
+    #Plt2.set_xlim(2.417990504024163e+20 *np.array(xlim))
+    #Plt2.set_xticklabels(np.array(np.log10(Plt2.get_xticks()),dtype=int))
+    #Plt2.set_xlabel('$\mathrm{\log_{10}\mathbf{(Frequency)} \\ \\ [Hz]}$')
+    
     #save the canvas
-    plt.savefig(filebase + '.png', dpi=150, facecolor='w', edgecolor='w',
+    #plt.grid()
+    plt.savefig("%s.png" %filebase, dpi=150, facecolor='w', edgecolor='w',
             orientation='portrait', papertype=None, format=None,
-            transparent=False, bbox_inches=None, pad_inches=0.1,
+            transparent=False, bbox_inch=None, pad_inches=0.1,
             frameon=None)
 
 def PlotUL(pars,config,ULFlux,Index):

--- a/enrico/plotting.py
+++ b/enrico/plotting.py
@@ -406,7 +406,7 @@ def plot_errorbar_withuls(x,xerrm,xerrp,y,yerrm,yerrp,uplim,bblocks=False):
             marker=None,ms=0,capsize=0,color='#d62728',zorder=-10,
             ls='None',label='bayesian blocks')
 
-    
+        plt.legend()
 
 def PlotSED(config,pars):
     """plot a nice SED with a butterfly and points"""

--- a/enrico/plotting.py
+++ b/enrico/plotting.py
@@ -406,7 +406,7 @@ def plot_errorbar_withuls(x,xerrm,xerrp,y,yerrm,yerrp,uplim,bblocks=False):
             marker=None,ms=0,capsize=0,color='#d62728',zorder=-10,
             ls='None',label='bayesian blocks')
 
-        plt.legend()
+        plt.legend(numpoints=1)
 
 def PlotSED(config,pars):
     """plot a nice SED with a butterfly and points"""

--- a/enrico/plotting.py
+++ b/enrico/plotting.py
@@ -371,11 +371,30 @@ def PlotSED(config,pars):
     if NEbin > 0:
         Epoint, Fluxpoint, EpointErrm, EpointErrp, FluxpointErrm, FluxpointErrp, uplim = GetDataPoints(config,pars) #collect data points
 
-    print uplim
-    print FluxpointErrm
-    print FluxpointErrp
+    #print uplim
+    #print FluxpointErrm
+    #print FluxpointErrp
     # plt.errorbar(Epoint, Fluxpoint, xerr=[EpointErrm, EpointErrp], yerr=[FluxpointErrm, FluxpointErrp],fmt='o',color='black',ls='None',uplims=uplim)
-    plt.errorbar(Epoint, Fluxpoint, xerr=[EpointErrm, EpointErrp], yerr=[FluxpointErrm, FluxpointErrp],fmt='o',capsize=0,color='black',ls='None',uplims=uplim,label='LAT ebins')
+    # Get the strict upper limit (best fit value + error, then set the error to 0 and the lower error to 20% of the value)
+    uplim = np.array(uplim,dtype=bool) # It is an array of 1 and 0s, needs to be a bool array.
+    Fluxpoint[uplim] += FluxpointErrp[uplim]
+    FluxpointErrm[uplim] = 0
+    FluxpointErrp[uplim] = 0
+
+    # Plot the significant points
+    plt.errorbar(Epoint[~uplim], Fluxpoint[~uplim], 
+        xerr=[EpointErrm[~uplim], EpointErrp[~uplim]], 
+        yerr=[FluxpointErrm[~uplim], FluxpointErrp[~uplim]],
+        fmt='o',capsize=0,color='black',ls='None',uplims=False,label='LAT ebins')
+    
+    # Plot the upper limits. For some reason, matplotlib draws the arrows inverted for uplim and lolim [?]
+    plt.errorbar(Epoint[uplim], Fluxpoint[uplim], 
+        xerr=[EpointErrm[uplim], EpointErrp[uplim]], 
+        yerr=[FluxpointErrm[uplim], FluxpointErrp[uplim]],
+        fmt='o',markersize=0,capsize=0,color='black',ls='None',uplims=False)
+    plt.errorbar(Epoint[uplim], 0.8*Fluxpoint[uplim], 
+        yerr=[0.2*Fluxpoint[uplim], 0.2*Fluxpoint[uplim]],
+        fmt='o',markersize=0,capsize=4,color='black',ls='None',lolims=True)
 
     #Set meaningful axes limits
     xlim = plt.xlim()

--- a/enrico/plotting.py
+++ b/enrico/plotting.py
@@ -57,7 +57,7 @@ class Result(Loggin.Message):
     def _DumpSED(self,par):
         """Save the energy, E2.dN/dE, and corresponding  error in an ascii file
         The count and residuals plot vs E is also made"""
-        
+
         try:
             self.decE
         except NameError:
@@ -133,7 +133,7 @@ class Result(Loggin.Message):
         src     = np.array([])
 
         # Summed Likelihood has no writeCountsSpectra
-        # but we can do it component by component 
+        # but we can do it component by component
         for comp in self.Fit.components:
             #self.Fit.writeCountsSpectra(imName)
             comp.writeCountsSpectra(imName)
@@ -170,7 +170,7 @@ class Result(Loggin.Message):
         Nbin  = len(src)
         E = np.array((emax + emin) / 2.)
         err_E = np.array((emax - emin) / 2.)
-        
+
         total = np.array(total)
         residual = np.zeros(Nbin)
         Dres = np.zeros(Nbin)
@@ -267,7 +267,7 @@ def GetDataPoints(config,pars):
         #E = int(pow(10, (np.log10(ener[i + 1]) + np.log10(ener[i])) / 2))
         filename = (config['out'] + '/'+EbinPath+str(NEbin)+'/' + config['target']['name'] +
                     "_" + str(i) + ".conf")
-        
+
         try:#read the config file of each data points
             CurConf = get_config(filename)
             mes.info("Reading "+filename)
@@ -326,47 +326,55 @@ def plot_errorbar_withuls(x,xerrm,xerrp,y,yerrm,yerrp,uplim,bblocks=False):
     """ plot an errorbar plot with upper limits. Optionally compute and draw bayesian blocks (bblocks) """
     # plt.errorbar(Epoint, Fluxpoint, xerr=[EpointErrm, EpointErrp], yerr=[FluxpointErrm, FluxpointErrp],fmt='o',color='black',ls='None',uplims=uplim)
     uplim = np.asarray(uplim,dtype=bool) # It is an array of 1 and 0s, needs to be a bool array.
-    # make sure that the arrays are numpy arrays and not lists. 
-    x = np.asarray(x) 
-    xerrm = np.asarray(xerrm) 
-    xerrp = np.asarray(xerrp) 
-    y = np.asarray(y) 
-    yerrm = np.asarray(yerrm) 
-    yerrp = np.asarray(yerrp) 
+    # make sure that the arrays are numpy arrays and not lists.
+    x = np.asarray(x)
+    xerrm = np.asarray(xerrm)
+    xerrp = np.asarray(xerrp)
+    y = np.asarray(y)
+    yerrm = np.asarray(yerrm)
+    yerrp = np.asarray(yerrp)
     # Get the strict upper limit (best fit value + error, then set the error to 0 and the lower error to 20% of the value)
     y[uplim] += yerrp[uplim]
     yerrm[uplim] = 0
     yerrp[uplim] = 0
 
+    optimal_markersize = (0.5+4./(1.+np.log10(len(y))))
+
     # Plot the significant points
-    plt.errorbar(x[~uplim], y[~uplim], 
-        xerr=[xerrm[~uplim], xerrp[~uplim]], 
+    plt.errorbar(x[~uplim], y[~uplim],
+        xerr=[xerrm[~uplim], xerrp[~uplim]],
         yerr=[yerrm[~uplim], yerrp[~uplim]],
-        fmt='o',capsize=0,color='black',ls='None',uplims=False,label='LAT data')
-    
+        fmt='o',ms=optimal_markersize,capsize=0,zorder=10,
+        color='black',ls='None',uplims=False,label='LAT data')
+
     # Plot the upper limits. For some reason, matplotlib draws the arrows inverted for uplim and lolim [?]
     # This is a known issue fixed in matplotlib 1.4: https://github.com/matplotlib/matplotlib/pull/2452
     if LooseVersion(matplotlib.__version__) < LooseVersion("1.4.0"):
-        plt.errorbar(x[uplim], y[uplim], 
-            xerr=[xerrm[uplim], xerrp[uplim]], 
+        plt.errorbar(x[uplim], y[uplim],
+            xerr=[xerrm[uplim], xerrp[uplim]],
             yerr=[yerrm[uplim], yerrp[uplim]],
-            fmt='o',markersize=0,capsize=0,color='0.50',ls='None',lolims=False)
-        plt.errorbar(x[uplim], 0.8*y[uplim], 
+            fmt='o',markersize=0,capsize=0,zorder=-1,
+            color='0.50',ls='None',lolims=False)
+        plt.errorbar(x[uplim], 0.8*y[uplim],
             yerr=[0.2*y[uplim], 0.2*y[uplim]],
-            fmt='o',markersize=0,capsize=4,color='0.50',ls='None',lolims=True)
+            fmt='o',markersize=0,capsize=optimal_markersize/1.5,zorder=-1,
+            color='0.50',ls='None',lolims=True)
     else:
-        plt.errorbar(x[uplim], y[uplim], 
-            xerr=[xerrm[uplim], xerrp[uplim]], 
+        plt.errorbar(x[uplim], y[uplim],
+            xerr=[xerrm[uplim], xerrp[uplim]],
             yerr=[yerrm[uplim], yerrp[uplim]],
-            fmt='o',markersize=0,capsize=0,color='0.50',ls='None',uplims=False)
-        plt.errorbar(x[uplim], 0.8*y[uplim], 
+            fmt='o',markersize=0,capsize=0,zorder=-1,
+            color='0.50',ls='None',uplims=False)
+        plt.errorbar(x[uplim], 0.8*y[uplim],
             yerr=[0.2*y[uplim], 0.2*y[uplim]],
-            fmt='o',markersize=0,capsize=4,color='0.50',ls='None',uplims=True)
+            fmt='o',markersize=0,capsize=optimal_markersize/1.5,zorder=-1,
+            color='0.50',ls='None',uplims=True)
 
     if bblocks:
         yerr = 0.5*(yerrm+yerrp)
+        # Set the value and error for the uls.
+        yerr[uplim] = y[uplim] #min(y[yerr>0]+yerr[yerr>0])
         y[uplim] = 0
-        yerr[uplim] = min(yerr[yerr>0])
         edges = bayesian_blocks(x,y,yerr,fitness='measures',p0=0.5)
         #edges = bayesian_blocks(x[yerr>0],y[yerr>0],yerr[yerr>0],fitness='measures',p0=0.1)
         xvalues = 0.5*(edges[:-1]+edges[1:])
@@ -395,18 +403,18 @@ def plot_errorbar_withuls(x,xerrm,xerrp,y,yerrm,yerrp,uplim,bblocks=False):
                 ystepmax.append(yvalues[k]+yerrors[k]) # 3 values, to mark the minimum and center
             xstep.append(xvalues[k]-xerrors[k])
             xstep.append(xvalues[k]+xerrors[k])
-            
-        plt.step(xstep, ystep, 
+
+        plt.step(xstep, ystep,
             color='#d62728',zorder=-10,
             ls='solid')
-        plt.fill_between(xstep, ystepmin, ystepmax, 
+        plt.fill_between(xstep, ystepmin, ystepmax,
             color='#d62728',zorder=-10, alpha=0.5)
-        plt.errorbar(xvalues, yvalues, 
+        plt.errorbar(xvalues, yvalues,
             xerr=xerrors,yerr=yerrors,
             marker=None,ms=0,capsize=0,color='#d62728',zorder=-10,
             ls='None',label='bayesian blocks')
 
-        plt.legend(numpoints=1)
+        plt.legend(loc=0,fontsize='small',numpoints=1)
 
 def PlotSED(config,pars):
     """plot a nice SED with a butterfly and points"""
@@ -473,10 +481,10 @@ def PlotSED(config,pars):
     plt.ylim(ylim)
     # turn them into log10 scale
     #xticks = plt.xticks()[0]
-    #xticklabels = np.array(np.log10(xticks),dtype=int) 
+    #xticklabels = np.array(np.log10(xticks),dtype=int)
     #plt.xticks(xticks,xticklabels)
     #plt.xlabel('$\mathrm{\log_{10}\mathbf{(Energy)} \\ \\ [MeV]}$')
-    
+
     plt.legend(fontsize='small',ncol=1,\
                loc=3,numpoints=1)#,framealpha=0.75)
 
@@ -487,7 +495,7 @@ def PlotSED(config,pars):
     #Plt2.set_xlim(2.417990504024163e+20 *np.array(xlim))
     #Plt2.set_xticklabels(np.array(np.log10(Plt2.get_xticks()),dtype=int))
     #Plt2.set_xlabel('$\mathrm{\log_{10}\mathbf{(Frequency)} \\ \\ [Hz]}$')
-    
+
     #save the canvas
     #plt.grid()
     plt.savefig("%s.png" %filebase, dpi=150, facecolor='w', edgecolor='w',
@@ -513,7 +521,7 @@ def PlotUL(pars,config,ULFlux,Index):
         plt.errorbar([E[0],E[-1]], [SED[0],SED[-1]],  yerr=[SED[0]*0.8,SED[-1]*0.8],fmt='.',color='black',ls='None',lolims=[1,1])
     else:
         plt.errorbar([E[0],E[-1]], [SED[0],SED[-1]],  yerr=[SED[0]*0.8,SED[-1]*0.8],fmt='.',color='black',ls='None',uplims=[1,1])
- 
+
     #save the plot
     filebase = utils._SpecFileName(config)
     plt.savefig(filebase + '.png', dpi=150, facecolor='w', edgecolor='w',

--- a/enrico/scan.py
+++ b/enrico/scan.py
@@ -7,6 +7,8 @@ import RunGTlike
 import ROOT
 import numpy,os,string,array
 from enrico import Loggin
+import matplotlib
+matplotlib.rc('text', usetex=True)
 import matplotlib.pyplot as plt
 
 def MakeScan(Fit,spectrum,par,bmin,bmax,opt,N=100):

--- a/enrico/xml_model.py
+++ b/enrico/xml_model.py
@@ -698,9 +698,11 @@ def XmlMaker(config):
       config["event"]["evtype"] = 512
       config["file"]["xml"] = xml.replace(".xml","_EDISP3.xml")
       WriteXml(lib, doc, srclist, config)
-      
     else :
       WriteXml(lib, doc, srclist, config)
+    
+    # Recover the old xml file.
+    config["file"]["xml"] = xml
 
     Xml_to_Reg(folder + "/Roi_model",
         srclist, Prog=sys.argv[0])


### PR DESCRIPTION
- Fixed: do not overwrite the XML file for the energy bins (particularly affecting the energy scale, which is used to fetch the central energy for the energy bin SED plot).
- Fixed: upper limit drawing (capsize=0 messing up the arrow drawing, array of 0 and 1s not interpreted as boolean array, upper limit and lower limit inverted in matplotlib ??)
- Some stylish improvements for matplotlib (use tex fonts always for consistency).
- Run gtpsf in any case (it is useful for DL3 exporters for instance) 
- Implementation of bayesian blocks (it can be triggered with the new config option

[LightCurve]
BayesianBlocks = option('yes', 'no', default='no')