### PR TITLE
Handle complex multi-component sources in XML model generator

### DIFF
--- a/enrico/config/default.conf
+++ b/enrico/config/default.conf
@@ -52,7 +52,11 @@ Submit = option('yes', 'no', default='no')
 	likelihood = option(binned, unbinned, default=binned)
 	# Correct energy dispersion?
 	EnergyDispersion = option('yes', 'no', default='yes')
+    # Compute diffuse response?
 	ComputeDiffrsp = option('yes', 'no', default='yes')
+	# Weights Map in gtlike?
+    UseWeightsMap = option('yes', 'no', default='yes')
+    # Avoid Earth limb
 	zmax = float(default=100)
 	roicut = option('yes', 'no', default='no')
 	# cuts applied during the first coarse bin selection:

--- a/enrico/fitmaker.py
+++ b/enrico/fitmaker.py
@@ -9,6 +9,7 @@ begun September 2011
 #import logging
 #logging.basicConfig(level=logging.INFO)
 #log = logging.getLogger(__name__)
+import os
 import numpy as np
 import string
 try:
@@ -106,12 +107,18 @@ class FitMaker(Loggin.Message):
         if self.config['analysis']['likelihood'] == 'binned':
             use_edisp  = self.config['analysis']['EnergyDispersion'] == 'yes'
             edisp_bins = -2 if use_edisp==True else 0
+            use_wmap  = self.config['analysis']['UseWeightsMap'] == 'yes'
+            wmap = None
+            if use_wmap:
+                if os.path.exists(self.obs.wtsmapfile):
+                    wmap = self.obs.wtsmapfile
+                
             Obs = BinnedObs(srcMaps=self.obs.srcMap,
                             expCube=self.obs.Cubename,
                             binnedExpMap=self.obs.BinnedMapfile,
                             irfs=self.obs.irfs)
             Cfg = BinnedConfig(use_edisp=use_edisp, 
-                               edisp_bins=edisp_bins)
+                               edisp_bins=edisp_bins,wmap=wmap)
             Fit = BinnedAnalysis(Obs, self.obs.xmlfile, config=Cfg,
                                  optimizer=self.config['fitting']['optimizer'])
             

--- a/enrico/xml_model.py
+++ b/enrico/xml_model.py
@@ -486,6 +486,7 @@ def GetlistFromFits(config, catalog):
     """Read the config and catalog file and generate the list of sources to include"""
     #Get the informations for the config file
     srcname = config['target']['name']
+    srcname_short = srcname.replace(' ','_')
     ra_src = config['target']['ra']
     dec_src = config['target']['dec']
     redshift = config['target']['redshift']
@@ -513,6 +514,7 @@ def GetlistFromFits(config, catalog):
     cfile = fits.open(catalog)
     data = cfile[1].data
     names = data.field('Source_Name')
+    names_short = [k.replace(' ','_') for k in names]
     ra = data.field('RAJ2000')
     dec = data.field('DEJ2000')
     flux = data.field('PL_Flux_Density')
@@ -650,20 +652,33 @@ def GetlistFromFits(config, catalog):
 
         
             if len(sources)>0:
-                if (sources[0]['name'] != srcname and srcname not in names) or (names[i] == srcname):
+                if srcname_short in names_short:
+                    if names_short[i] == srcname_short:
+                        # Target source, srcname matches that in the catalog. e.g. J0534.5+2201i
+                        mes.info("---> Adding [free] target source, Catalog name is %s, dist is %.2f and TS is %.2f" %(names[i],rsrc,sigma[i]) )
+                        sources.insert(0,{'name': srcname, 'ra': ra_src, 'dec': dec_src,
+                                          'flux': flux[i], 'index': -index[i], 'scale': pivot[i],
+                                          'cutoff': cutoff[i], 'beta': beta[i], 'expfac': expfac[i], 'expind': expind[i],
+                                          'IsFree': 1, 'IsFreeShape' : 1,
+                                          'SpectrumType': spectype[i], 'ExtendedName': extended_fitsfilename})
+                    else:
+                        # This is a co-spatial source, e.g. J0534.5+2201s
+                        mes.info("(!!) Adding [fixed] co-spatial source, Catalog name is %s, dist is %.2f and TS is %.2f" %(names[i],rsrc,sigma[i]) )
+                        sources.append({'name': names[i], 'ra': ra_src, 'dec': dec_src,
+                                        'flux': flux[i], 'index': -index[i], 'scale': pivot[i],
+                                        'cutoff': cutoff[i], 'beta': beta[i], 'expfac': expfac[i], 'expind': expind[i],
+                                        'IsFree': 0, 'IsFreeShape' : 0,
+                                        'SpectrumType': spectype[i], 'ExtendedName': extended_fitsfilename})
+                else:
+                    # This is the unclear case. User specifies a srcname not in the catalog. There might be several
+                    # co-spatial sources, but we are unsure which one the user wants. Add a single 'sum' source (e.g.
+                    # CrabTotal = CrabPulsar + CrabNebula). 
                     mes.info("---> Adding [free] target source, Catalog name is %s, dist is %.2f and TS is %.2f" %(names[i],rsrc,sigma[i]) )
                     sources.insert(0,{'name': srcname, 'ra': ra_src, 'dec': dec_src,
                                       'flux': flux[i], 'index': -index[i], 'scale': pivot[i],
                                       'cutoff': cutoff[i], 'beta': beta[i], 'expfac': expfac[i], 'expind': expind[i],
                                       'IsFree': 1, 'IsFreeShape' : 1,
                                       'SpectrumType': spectype[i], 'ExtendedName': extended_fitsfilename})
-                else:
-                    mes.info("(!!) Adding [fixed] co-spatial source, Catalog name is %s, dist is %.2f and TS is %.2f" %(names[i],rsrc,sigma[i]) )
-                    sources.append({'name': names[i], 'ra': ra_src, 'dec': dec_src,
-                                    'flux': flux[i], 'index': -index[i], 'scale': pivot[i],
-                                    'cutoff': cutoff[i], 'beta': beta[i], 'expfac': expfac[i], 'expind': expind[i],
-                                    'IsFree': 0, 'IsFreeShape' : 0,
-                                    'SpectrumType': spectype[i], 'ExtendedName': extended_fitsfilename})
 
 
         elif rsrc < max_radius and rsrc >= .1 and sigma[i] > min_significance_free:


### PR DESCRIPTION
Before: 

- Sources that are very close: assume it is the target source and add it at the beginning of the XML with free parameters. 
- Problem: Crab in 4FGL has Crab Nebula sync + Crab Nebula IC + Crab pulsar as 3 sources. Enrico analysis is done in just a single source (Crab 'total').

Now

- If the input srcname is in the 4FGL, then that is the target source (e.g. J0534.5+2201i --> Crab Nebula IC). Other co-spatial sources (e.g. J0534.5+2201s or J0534.5+2200 --> Crab Nebula Sync and Crab Pulsar) are added too, but with FIXED parameters.
- If the input srcname is not in the 4FGL, do the 'total' analysis with a single source as before. 