### PR TITLE
Allow to remove files except those needed for gammapy after analysis

### DIFF
--- a/enrico/RunGTlike.py
+++ b/enrico/RunGTlike.py
@@ -276,8 +276,10 @@ def run(infile):
     energybin.RunEbin(folder,Nbin,Fit,FitRunner,sedresult)
     
     # Cleanup files for this analysis? (this is supposed to be done only for bins, to save up space) 
-    if config['file']['FitsCleanupAfterAnalysis'] == 'yes':
-        utils.CleanUpFitsFiles(config)
+    if config['file']['FitsCleanupAfterAnalysis']=='minimal':
+        utils.CleanUpFitsFiles(config,keep_minimal=True)
+    elif config['file']['FitsCleanupAfterAnalysis']=='yes':
+        utils.CleanUpFitsFiles(config,keep_minimal=False)
 
     del(sedresult)
     del(Result)

--- a/enrico/config/default.conf
+++ b/enrico/config/default.conf
@@ -149,7 +149,8 @@ Submit = option('yes', 'no', default='no')
 [LightCurve]
     #Generates fits files or not?
     FitsGeneration = option('yes', 'no', default='yes')
-    #Cleanup all fits files upon finishing analysis.
+    #Cleanup all fits files upon finishing analysis 
+    #(yes=cleanup, no=keep, minimal=keep photon list with GTIs + DRM + Exposure + PSF).
     FitsCleanupAfterAnalysis = option('yes', 'no', 'minimal', default='no')
     #Number of points for the LC
     NLCbin = integer(default = 20)

--- a/enrico/config/default.conf
+++ b/enrico/config/default.conf
@@ -24,7 +24,7 @@ Submit = option('yes', 'no', default='no')
     parent_config = string(default='')
     compress_fits = option('yes', 'no', default='no')
     #Cleanup all fits files upon finishing analysis (warning: this will remove all FITS files).
-    FitsCleanupAfterAnalysis = option('yes', 'no', default='no')
+    FitsCleanupAfterAnalysis = option('yes', 'no', 'minimal', default='no')
 
 [environ]
     # Analysis environment configuration
@@ -150,7 +150,7 @@ Submit = option('yes', 'no', default='no')
     #Generates fits files or not?
     FitsGeneration = option('yes', 'no', default='yes')
     #Cleanup all fits files upon finishing analysis.
-    FitsCleanupAfterAnalysis = option('yes', 'no', default='no')
+    FitsCleanupAfterAnalysis = option('yes', 'no', 'minimal', default='no')
     #Number of points for the LC
     NLCbin = integer(default = 20)
     #Fixed time bin edges (path to text file, 1-column)
@@ -213,7 +213,7 @@ Submit = option('yes', 'no', default='no')
     #Generates fits files or not?
     FitsGeneration = option('yes', 'no', default='yes')
     #Cleanup all fits files upon finishing analysis.
-    FitsCleanupAfterAnalysis = option('yes', 'no', default='no')
+    FitsCleanupAfterAnalysis = option('yes', 'no', 'minimal', default='no')
     # Number of energy bins
     NumEnergyBins = integer(default=0)
     #Compute an UL if the TS of the sources is <TSEnergyBins

--- a/enrico/config/default.conf
+++ b/enrico/config/default.conf
@@ -163,7 +163,7 @@ Submit = option('yes', 'no', default='no')
     #Bayesian blocks
     BayesianBlocks = option('yes', 'no', default='no')
     #Compute Variability index as in the 2FGL.
-    ComputeVarIndex = option('yes', 'no', default='yes')
+    ComputeVarIndex = option('yes', 'no', default='no')
     #Compute an UL if the TS of the sources is <TSLightCurve
     TSLightCurve = float(default=9)
     #Generates control plots

--- a/enrico/energybin.py
+++ b/enrico/energybin.py
@@ -206,8 +206,7 @@ def PrepareEbin(Fit, FitRunner,sedresult=None):
             config['Submit'] = 'no'
         
         # cleanup files from this bin after the analysis is done?
-        if config['Ebin']['FitsCleanupAfterAnalysis'] == 'yes':
-            config['file']['FitsCleanupAfterAnalysis'] = 'yes'
+        config['file']['FitsCleanupAfterAnalysis'] = config['Ebin']['FitsCleanupAfterAnalysis']
         
         config['file']['tag'] = tag + '_Ebin' + str(NEbin) + '_' + str(ibin)
         filename =  config['target']['name'] + "_" + str(ibin) + ".conf"

--- a/enrico/extern/astropy_bayesian_blocks.py
+++ b/enrico/extern/astropy_bayesian_blocks.py
@@ -43,7 +43,12 @@ import warnings
 import numpy as np
 import types
 #from funcsigs import signature
-from inspect import getargspec
+try:
+    # Python 3.0–3.10
+    from inspect import getfullargspec as getargspec
+except ImportError:
+    # fallback for very old Pythons
+    from inspect import getargspec
 
 # TODO: implement other fitness functions from appendix B of Scargle 2012
 

--- a/enrico/lightcurve.py
+++ b/enrico/lightcurve.py
@@ -207,14 +207,14 @@ class LightCurve(Loggin.Message):
                        self.config['analysis']['likelihood'] +
                        "_LC_" + self.config['file']['tag'])+"_"+str(i)+".log"
 
-                if environ.FARM in ["IAC_DIVA"]:
+                if environ.FARM in ["IAC_DIVA", "IAC_DAMPE"]:
                     cmd_list.append(cmd)
                 else:
                     call(cmd,enricodir,fermidir,scriptname,JobLog,JobName)
             else :
                 os.system(cmd)
         
-        nmax = 100
+        nmax = 999
         if len(cmd_list)>0:    
             if len(cmd_list)>nmax:
                 cmd_list_split = [cmd_list[i * nmax:(i + 1) * nmax] for i in range((len(cmd_list) + nmax - 1) // nmax )]

--- a/enrico/lightcurve.py
+++ b/enrico/lightcurve.py
@@ -173,8 +173,7 @@ class LightCurve(Loggin.Message):
             # Do not produce spectral plots
             
             # cleanup the fits files of this bin after the analysis is done
-            if self.config['LightCurve']['FitsCleanupAfterAnalysis'] == 'yes':
-                self.config['file']['FitsCleanupAfterAnalysis'] = 'yes'
+            self.config['file']['FitsCleanupAfterAnalysis'] = self.config['LightCurve']['FitsCleanupAfterAnalysis']
 
             if len(self.gtifile)==1:
                 self.config['time']['file']=self.gtifile[0]

--- a/enrico/utils.py
+++ b/enrico/utils.py
@@ -275,7 +275,7 @@ def CleanUpFitsFiles(config, keep_minimal=False):
     """Remove FITS files from destination directory"""
     fits_extensions = ['fits', 'fits.gz', 'fit', 'fit.gz']
     keep_keywords = ["_BinnedMap", "_eDRM", "_CountMap", "_ModelMap", 
-                     "_psf", "_ResidualMap", "_SubtractMap", "_Mktime", 
+                     "_psf", "_ResidualMap", "_SubtractMap", "_MkTime", 
                      "_GTI"]
 
     for ftype in fits_extensions:

--- a/enrico/utils.py
+++ b/enrico/utils.py
@@ -263,7 +263,7 @@ def CleanUpFitsFiles(config, keep_minimal=False):
     fits_extensions = ['fits', 'fits.gz', 'fit', 'fit.gz']
     keep_keywords = ["_BinnedMap", "_eDRM", "_CountMap", "_ModelMap", 
                      "_psf", "_ResidualMap", "_SubtractMap", "_MkTime", 
-                     "_GTI"]
+                     "_GTI","_alphabkgfile"]
 
     for ftype in fits_extensions:
         filetag = self.Configuration['file']['tag']

--- a/enrico/utils.py
+++ b/enrico/utils.py
@@ -266,7 +266,8 @@ def CleanUpFitsFiles(config, keep_minimal=False):
                      "_GTI"]
 
     for ftype in fits_extensions:
-        for f in glob.glob(os.path.join(config['out'], f"*.{ftype}")):
+        filetag = self.Configuration['file']['tag']
+        for f in glob.glob(os.path.join(config['out'], f"*{filetag}*.{ftype}")):
             if keep_minimal and any(keyword in f for keyword in keep_keywords):
                 continue  # Skip deletion if the file should be kept
             

--- a/enrico/utils.py
+++ b/enrico/utils.py
@@ -258,19 +258,6 @@ def _SpecFileName(config):
     from enrico.constants import SpectrumPath
     return  config['out'] + '/'+SpectrumPath+'/SED_' + config['target']['name'] +'_'+ config['target']['spectrum']
 
-#def CleanUpFitsFiles(config,keep_gammapy=False):
-#    """Remove FITS files from destination directory"""
-#    keepit=False
-#    for ftype in ['fits', 'fits.gz','fit','fit.gz']:
-#        for f in os.path.join(config['out'], f"*.{ftype}"):
-#            if keep_gammapy:
-#                keepit=False
-#                for fkeep in ["_BinnedMap","_eDRM","_CountMap","_ModelMap","_psf","_ResidualMap","_SubtractMap","_Mktime",".result","_GTI"]:
-#                    if fkeep in f:
-#                        keepit=True
-#            if not keepit:
-#                shutil.rmtree(f,ignore_errors=True)
-
 def CleanUpFitsFiles(config, keep_minimal=False):
     """Remove FITS files from destination directory"""
     fits_extensions = ['fits', 'fits.gz', 'fit', 'fit.gz']

--- a/enrico/utils.py
+++ b/enrico/utils.py
@@ -258,12 +258,35 @@ def _SpecFileName(config):
     from enrico.constants import SpectrumPath
     return  config['out'] + '/'+SpectrumPath+'/SED_' + config['target']['name'] +'_'+ config['target']['spectrum']
 
-def CleanUpFitsFiles(config):
-    """Remove FITS files from destination directory"""
-    for ftype in ['fits', 'fits.gz','fit','fit.gz']:
-        for f in glob.glob(config['out']+'/*.'+ftype):
-            shutil.rmtree(f,ignore_errors=True)
+#def CleanUpFitsFiles(config,keep_gammapy=False):
+#    """Remove FITS files from destination directory"""
+#    keepit=False
+#    for ftype in ['fits', 'fits.gz','fit','fit.gz']:
+#        for f in os.path.join(config['out'], f"*.{ftype}"):
+#            if keep_gammapy:
+#                keepit=False
+#                for fkeep in ["_BinnedMap","_eDRM","_CountMap","_ModelMap","_psf","_ResidualMap","_SubtractMap","_Mktime",".result","_GTI"]:
+#                    if fkeep in f:
+#                        keepit=True
+#            if not keepit:
+#                shutil.rmtree(f,ignore_errors=True)
 
+def CleanUpFitsFiles(config, keep_minimal=False):
+    """Remove FITS files from destination directory"""
+    fits_extensions = ['fits', 'fits.gz', 'fit', 'fit.gz']
+    keep_keywords = ["_BinnedMap", "_eDRM", "_CountMap", "_ModelMap", 
+                     "_psf", "_ResidualMap", "_SubtractMap", "_Mktime", 
+                     "_GTI"]
+
+    for ftype in fits_extensions:
+        for f in glob.glob(os.path.join(config['out'], f"*.{ftype}")):
+            if keep_minimal and any(keyword in f for keyword in keep_keywords):
+                continue  # Skip deletion if the file should be kept
+            
+            try:
+                os.remove(f)
+            except OSError as e:
+                print(f"Error removing {f}: {e}")
 
 def _dump_xml(config) :
     """Give the name of the XML file where the results will be save by gtlike"""

--- a/enrico/utils.py
+++ b/enrico/utils.py
@@ -266,7 +266,7 @@ def CleanUpFitsFiles(config, keep_minimal=False):
                      "_GTI","_alphabkgfile"]
 
     for ftype in fits_extensions:
-        filetag = self.Configuration['file']['tag']
+        filetag = config['file']['tag']
         for f in glob.glob(os.path.join(config['out'], f"*{filetag}*.{ftype}")):
             if keep_minimal and any(keyword in f for keyword in keep_keywords):
                 continue  # Skip deletion if the file should be kept


### PR DESCRIPTION
cleanup of files except those needed for gammapy is triggered by setting minimal as config option, off by default. 

Only the DRM, PSF, MkTime (photon list + GTIs) and Binned Exposure files will be kept if activated. These are the files required to create Gammapy's MapDatasets. 